### PR TITLE
Move ComponentValue dataclass to shared module

### DIFF
--- a/src/omym/features/path/__init__.py
+++ b/src/omym/features/path/__init__.py
@@ -1,8 +1,9 @@
-"""Public API for the path feature."""
+"""Public API for the path feature (domain + use cases)."""
+
+from omym.shared.path_components import ComponentValue
 
 from .domain.sanitizer import Sanitizer
 from .domain.path_elements import (
-    ComponentValue,
     PathComponent,
     PathComponentFactory,
     AlbumArtistComponent,

--- a/src/omym/features/path/domain/path_elements.py
+++ b/src/omym/features/path/domain/path_elements.py
@@ -1,21 +1,17 @@
-"""Path component handling functionality."""
+"""Domain-level path component behavior for building file paths.
+
+This module defines the polymorphic path component abstractions used to
+generate filesystem paths from track metadata. ComponentValue is imported
+from the shared layer so adapters and the domain agree on the structure.
+"""
 
 from abc import ABC, abstractmethod
 from typing import final, ClassVar, override
-from dataclasses import dataclass
 
 from omym.features.metadata.domain.track_metadata import TrackMetadata
 from omym.features.path.domain.sanitizer import Sanitizer
 from omym.platform.logging import logger
-
-
-@dataclass
-class ComponentValue:
-    """Value and metadata for a path component."""
-
-    value: str
-    order: int
-    type: str
+from omym.shared.path_components import ComponentValue
 
 
 class PathComponent(ABC):

--- a/src/omym/platform/db/daos/path_elements_dao.py
+++ b/src/omym/platform/db/daos/path_elements_dao.py
@@ -1,9 +1,14 @@
-"""Data access object for path components."""
+"""Adapter layer DAO for path components stored in SQLite.
+
+This module persists ComponentValue records generated in the path domain
+model. Importing the dataclass from the shared layer keeps adapters in sync
+with the domain types while avoiding duplicate definitions.
+"""
 
 from sqlite3 import Connection
 from typing import final
 
-from omym.features.path.domain.path_elements import ComponentValue
+from omym.shared.path_components import ComponentValue
 from omym.platform.logging import logger
 
 

--- a/src/omym/shared/__init__.py
+++ b/src/omym/shared/__init__.py
@@ -1,0 +1,5 @@
+"""Shared cross-cutting utilities exposed at the package level."""
+
+from .path_components import ComponentValue
+
+__all__ = ["ComponentValue"]

--- a/src/omym/shared/path_components.py
+++ b/src/omym/shared/path_components.py
@@ -1,0 +1,17 @@
+"""Shared path component value objects (domain <-> adapters).
+
+This module centralizes the ComponentValue dataclass so both the path
+feature and persistence layers rely on a single definition. That ensures
+consistent typing across module boundaries without duplicating logic.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ComponentValue:
+    """Value and metadata describing a single path component."""
+
+    value: str
+    order: int
+    type: str

--- a/src/omym/shared/path_components.py
+++ b/src/omym/shared/path_components.py
@@ -7,6 +7,8 @@ consistent typing across module boundaries without duplicating logic.
 
 from dataclasses import dataclass
 
+__all__ = ["ComponentValue"]
+
 
 @dataclass
 class ComponentValue:

--- a/tests/features/path/test_path_elements.py
+++ b/tests/features/path/test_path_elements.py
@@ -3,6 +3,7 @@
 import pytest
 from typing import override
 
+from omym.shared import ComponentValue as ExportedComponentValue
 from omym.shared.path_components import ComponentValue
 from omym.features.path.domain.path_elements import (
     PathComponent,
@@ -41,6 +42,11 @@ def test_component_value() -> None:
     assert value.value == "test"
     assert value.order == 1
     assert value.type == "TestType"
+
+
+def test_shared_component_value_reexport() -> None:
+    """Ensure ComponentValue is re-exported from the shared package."""
+    assert ExportedComponentValue is ComponentValue
 
 
 def test_album_artist_component_with_album_artist(metadata: TrackMetadata) -> None:

--- a/tests/features/path/test_path_elements.py
+++ b/tests/features/path/test_path_elements.py
@@ -3,8 +3,8 @@
 import pytest
 from typing import override
 
+from omym.shared.path_components import ComponentValue
 from omym.features.path.domain.path_elements import (
-    ComponentValue,
     PathComponent,
     AlbumArtistComponent,
     AlbumComponent,


### PR DESCRIPTION
## Summary
- add a shared `ComponentValue` dataclass module for reuse across domain and adapters
- update path feature, DAO, and tests to import the shared dataclass

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68dfa0b1c5b4832a937e4919e2959b47