### PR TITLE
Move preview cache entry definition into shared module

### DIFF
--- a/src/omym/features/metadata/usecases/ports.py
+++ b/src/omym/features/metadata/usecases/ports.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from sqlite3 import Connection
 from typing import Protocol, runtime_checkable
 
-from omym.shared.previews import PreviewCacheEntry
+from omym.shared import PreviewCacheEntry
 
 
 @runtime_checkable

--- a/src/omym/features/metadata/usecases/ports.py
+++ b/src/omym/features/metadata/usecases/ports.py
@@ -7,10 +7,11 @@ Why: Decouple use cases from concrete DB and cache adapters for testing and swap
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from sqlite3 import Connection
 from typing import Protocol, runtime_checkable
+
+from omym.shared.previews import PreviewCacheEntry
 
 
 @runtime_checkable
@@ -82,17 +83,6 @@ class ArtistCachePort(Protocol):
     def clear_cache(self) -> bool:
         """Erase cached artist data."""
         ...
-
-
-@dataclass(frozen=True, slots=True)
-class PreviewCacheEntry:
-    """Value object describing a cached dry-run preview."""
-
-    file_hash: str
-    source_path: Path
-    base_path: Path
-    target_path: Path | None
-    payload: dict[str, object]
 
 
 @runtime_checkable

--- a/src/omym/platform/db/daos/processing_preview_dao.py
+++ b/src/omym/platform/db/daos/processing_preview_dao.py
@@ -10,7 +10,7 @@ import sqlite3
 from pathlib import Path
 from typing import Final, cast
 
-from omym.shared.previews import PreviewCacheEntry
+from omym.shared import PreviewCacheEntry
 from omym.platform.logging import logger
 
 

--- a/src/omym/platform/db/daos/processing_preview_dao.py
+++ b/src/omym/platform/db/daos/processing_preview_dao.py
@@ -10,7 +10,7 @@ import sqlite3
 from pathlib import Path
 from typing import Final, cast
 
-from omym.features.metadata.usecases.ports import PreviewCacheEntry
+from omym.shared.previews import PreviewCacheEntry
 from omym.platform.logging import logger
 
 

--- a/src/omym/shared/__init__.py
+++ b/src/omym/shared/__init__.py
@@ -1,5 +1,6 @@
 """Shared cross-cutting utilities exposed at the package level."""
 
 from .path_components import ComponentValue
+from .previews import PreviewCacheEntry
 
-__all__ = ["ComponentValue"]
+__all__ = ["ComponentValue", "PreviewCacheEntry"]

--- a/src/omym/shared/previews.py
+++ b/src/omym/shared/previews.py
@@ -1,0 +1,25 @@
+"""Shared preview cache value objects (domain <-> adapters).
+
+Where: shared/.
+What: Dataclasses describing cached dry-run previews reused across layers.
+Why: Centralize the preview cache contract so ports and adapters stay in sync.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["PreviewCacheEntry"]
+
+
+@dataclass(frozen=True, slots=True)
+class PreviewCacheEntry:
+    """Value object describing a cached dry-run preview."""
+
+    file_hash: str
+    source_path: Path
+    base_path: Path
+    target_path: Path | None
+    payload: dict[str, object]
+

--- a/tests/features/metadata/test_file_runner_reorganize.py
+++ b/tests/features/metadata/test_file_runner_reorganize.py
@@ -18,7 +18,6 @@ from omym.features.metadata.usecases.ports import (
     ArtistCachePort,
     ProcessingAfterPort,
     ProcessingBeforePort,
-    PreviewCacheEntry,
     PreviewCachePort,
 )
 from omym.features.path.usecases.renamer import (
@@ -26,6 +25,7 @@ from omym.features.path.usecases.renamer import (
     DirectoryGenerator,
     FileNameGenerator,
 )
+from omym.shared.previews import PreviewCacheEntry
 
 from pytest_mock import MockerFixture
 

--- a/tests/features/metadata/test_file_runner_reorganize.py
+++ b/tests/features/metadata/test_file_runner_reorganize.py
@@ -25,7 +25,7 @@ from omym.features.path.usecases.renamer import (
     DirectoryGenerator,
     FileNameGenerator,
 )
-from omym.shared.previews import PreviewCacheEntry
+from omym.shared import PreviewCacheEntry
 
 from pytest_mock import MockerFixture
 

--- a/tests/features/metadata/test_music_file_processor.py
+++ b/tests/features/metadata/test_music_file_processor.py
@@ -19,7 +19,7 @@ from omym.features.metadata import (
     ProcessingEvent,
     ProcessResult,
 )
-from omym.shared.previews import PreviewCacheEntry
+from omym.shared import PreviewCacheEntry
 
 
 @pytest.fixture

--- a/tests/features/metadata/test_music_file_processor.py
+++ b/tests/features/metadata/test_music_file_processor.py
@@ -19,7 +19,7 @@ from omym.features.metadata import (
     ProcessingEvent,
     ProcessResult,
 )
-from omym.features.metadata.usecases.ports import PreviewCacheEntry
+from omym.shared.previews import PreviewCacheEntry
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- move the PreviewCacheEntry dataclass into src/omym/shared/previews.py for shared reuse
- update metadata use case ports, DAO, and tests to import the shared definition

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68dffa5da75c832aab73db5e9d8f3e95