### PR TITLE
refactor: move TrackMetadata to shared module

### DIFF
--- a/src/omym/features/metadata/__init__.py
+++ b/src/omym/features/metadata/__init__.py
@@ -1,6 +1,10 @@
+# Where: omym.features.metadata.__init__
+# What: Expose metadata feature services and shared dataclasses.
+# Why: Provide a cohesive import surface for UI and integration layers.
+
 """Public API for the metadata feature."""
 
-from .domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from .usecases.extraction import ArtistRomanizer, MetadataExtractor
 from .usecases.music_file_processor import MusicProcessor
 from .usecases.processing_types import (

--- a/src/omym/features/metadata/usecases/directory_runner.py
+++ b/src/omym/features/metadata/usecases/directory_runner.py
@@ -24,7 +24,7 @@ from .processing_types import (
 from .extraction.romanization import RomanizationCoordinator
 from .extraction.track_metadata_extractor import MetadataExtractor
 from .ports import DatabaseManagerPort
-from ..domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 
 class ProcessorLike(Protocol):

--- a/src/omym/features/metadata/usecases/extraction/_base_extractors.py
+++ b/src/omym/features/metadata/usecases/extraction/_base_extractors.py
@@ -16,7 +16,7 @@ from mutagen._util import MutagenError
 from omym.platform.logging import logger
 
 from ._tag_utils import parse_slash_separated, parse_year, safe_get_first
-from ...domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 if TYPE_CHECKING:
     from mutagen import MutagenTags

--- a/src/omym/features/metadata/usecases/extraction/artist_romanizer.py
+++ b/src/omym/features/metadata/usecases/extraction/artist_romanizer.py
@@ -19,7 +19,7 @@ from omym.platform.logging import logger
 from omym.platform.musicbrainz.client import fetch_romanized_name
 from omym.platform.musicbrainz.cache import save_cached_name
 
-from ...domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 ArtistFetcher = Callable[[str], str | None]
 LanguageDetector = Callable[[str], str | None]

--- a/src/omym/features/metadata/usecases/extraction/track_metadata_extractor.py
+++ b/src/omym/features/metadata/usecases/extraction/track_metadata_extractor.py
@@ -17,7 +17,7 @@ from .format_extractors import (
     OpusExtractor,
 )
 from .artist_romanizer import ArtistRomanizer
-from ...domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 __all__ = [
     "MetadataExtractor",

--- a/src/omym/features/metadata/usecases/file_operations.py
+++ b/src/omym/features/metadata/usecases/file_operations.py
@@ -19,7 +19,7 @@ from omym.platform.logging import logger
 
 from .associated_assets import ProcessLogger
 from .processing_types import ProcessingEvent
-from ..domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 
 def calculate_file_hash(file_path: Path) -> str:

--- a/src/omym/features/metadata/usecases/file_runner.py
+++ b/src/omym/features/metadata/usecases/file_runner.py
@@ -38,7 +38,7 @@ from .ports import (
 from .processing_types import ProcessResult, ProcessingEvent
 from .extraction.romanization import RomanizationCoordinator
 from .extraction.track_metadata_extractor import MetadataExtractor
-from ..domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 
 LOGGER = logging.getLogger(__name__)

--- a/src/omym/features/metadata/usecases/file_success.py
+++ b/src/omym/features/metadata/usecases/file_success.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from ..domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from .associated_assets import process_artwork, process_lyrics, summarize_artwork, summarize_lyrics
 from .processing_types import ProcessResult, ProcessingEvent
 from .file_context import FileProcessingContext

--- a/src/omym/features/metadata/usecases/music_file_processor.py
+++ b/src/omym/features/metadata/usecases/music_file_processor.py
@@ -31,7 +31,7 @@ from omym.platform.db.db_manager import DatabaseManager
 from omym.platform.logging import logger
 from omym.platform.musicbrainz.client import configure_romanization_cache
 
-from ..domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from .directory_runner import run_directory_processing
 from .file_runner import run_file_processing
 from .file_operations import calculate_file_hash, generate_target_path, move_file

--- a/src/omym/features/metadata/usecases/processing_types.py
+++ b/src/omym/features/metadata/usecases/processing_types.py
@@ -17,7 +17,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-from ..domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 
 class ProcessingEvent(StrEnum):

--- a/src/omym/features/path/domain/path_elements.py
+++ b/src/omym/features/path/domain/path_elements.py
@@ -8,7 +8,7 @@ from the shared layer so adapters and the domain agree on the structure.
 from abc import ABC, abstractmethod
 from typing import final, ClassVar, override
 
-from omym.features.metadata.domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from omym.features.path.domain.sanitizer import Sanitizer
 from omym.platform.logging import logger
 from omym.shared.path_components import ComponentValue

--- a/src/omym/features/path/usecases/renamer/directory.py
+++ b/src/omym/features/path/usecases/renamer/directory.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar, final
 
-from omym.features.metadata.domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from omym.features.path.domain.sanitizer import Sanitizer
 from omym.platform.logging import logger
 

--- a/src/omym/features/path/usecases/renamer/filename.py
+++ b/src/omym/features/path/usecases/renamer/filename.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import ClassVar, final
 
-from omym.features.metadata.domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from omym.features.path.domain.sanitizer import Sanitizer
 from omym.platform.logging import logger
 

--- a/src/omym/shared/__init__.py
+++ b/src/omym/shared/__init__.py
@@ -1,6 +1,11 @@
+# Where: omym.shared.__init__
+# What: Provide a concise import surface for shared utilities and dataclasses.
+# Why: Encourage consistent reuse of shared helpers across features.
+
 """Shared cross-cutting utilities exposed at the package level."""
 
 from .path_components import ComponentValue
 from .previews import PreviewCacheEntry
+from .track_metadata import TrackMetadata
 
-__all__ = ["ComponentValue", "PreviewCacheEntry"]
+__all__ = ["ComponentValue", "PreviewCacheEntry", "TrackMetadata"]

--- a/src/omym/shared/track_metadata.py
+++ b/src/omym/shared/track_metadata.py
@@ -1,4 +1,8 @@
-"""Metadata related functionality."""
+# Where: omym.shared.track_metadata
+# What: Canonical TrackMetadata dataclass shared across features.
+# Why: Centralize metadata representation for reuse and consistency.
+
+"""Shared dataclass representing track metadata."""
 
 from dataclasses import dataclass
 
@@ -18,3 +22,6 @@ class TrackMetadata:
     disc_number: int | None = None
     disc_total: int | None = None
     file_extension: str | None = None
+
+
+__all__ = ["TrackMetadata"]

--- a/tests/features/metadata/test_artist_romanizer.py
+++ b/tests/features/metadata/test_artist_romanizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pytest_mock import MockerFixture
 
 from omym.features.metadata import ArtistRomanizer
-from omym.features.metadata import TrackMetadata
+from omym.shared import TrackMetadata
 
 
 class TestArtistRomanizer:

--- a/tests/features/metadata/test_file_runner_reorganize.py
+++ b/tests/features/metadata/test_file_runner_reorganize.py
@@ -25,11 +25,10 @@ from omym.features.path.usecases.renamer import (
     DirectoryGenerator,
     FileNameGenerator,
 )
-from omym.shared import PreviewCacheEntry
+from omym.shared import PreviewCacheEntry, TrackMetadata
 
 from pytest_mock import MockerFixture
 
-from omym.features.metadata import TrackMetadata
 from omym.features.metadata.usecases.extraction.romanization import RomanizationCoordinator
 from omym.features.metadata.usecases.file_runner import run_file_processing
 

--- a/tests/features/metadata/test_metadata_extractor.py
+++ b/tests/features/metadata/test_metadata_extractor.py
@@ -12,8 +12,8 @@ import pytest
 from pytest_mock import MockerFixture
 
 from omym.features.metadata import ArtistRomanizer
-from omym.features.metadata import TrackMetadata
 from omym.features.metadata import MetadataExtractor
+from omym.shared import TrackMetadata
 
 # Type aliases for metadata dictionaries
 MP3Metadata: TypeAlias = dict[str, list[str]]

--- a/tests/features/metadata/test_music_file_processor.py
+++ b/tests/features/metadata/test_music_file_processor.py
@@ -11,7 +11,6 @@ import pytest
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 
-from omym.features.metadata import TrackMetadata
 from omym.config.settings import UNPROCESSED_DIR_NAME
 from omym.features.metadata import (
     DirectoryRollbackError,
@@ -19,7 +18,7 @@ from omym.features.metadata import (
     ProcessingEvent,
     ProcessResult,
 )
-from omym.shared import PreviewCacheEntry
+from omym.shared import PreviewCacheEntry, TrackMetadata
 
 
 @pytest.fixture

--- a/tests/features/path/test_file_name_padding.py
+++ b/tests/features/path/test_file_name_padding.py
@@ -1,4 +1,4 @@
-from omym.features.metadata.domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from omym.features.path.usecases.renamer import FileNameGenerator, CachedArtistIdGenerator
 from omym.platform.db.db_manager import DatabaseManager
 from omym.platform.db.cache.artist_cache_dao import ArtistCacheDAO

--- a/tests/features/path/test_music_file_renamer.py
+++ b/tests/features/path/test_music_file_renamer.py
@@ -7,7 +7,7 @@ from omym.features.path.usecases.renamer import (
     CachedArtistIdGenerator,
     DirectoryGenerator,
 )
-from omym.features.metadata.domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 from omym.platform.db.cache.artist_cache_dao import ArtistCacheDAO
 from omym.platform.db.db_manager import DatabaseManager
 

--- a/tests/features/path/test_path_elements.py
+++ b/tests/features/path/test_path_elements.py
@@ -11,7 +11,7 @@ from omym.features.path.domain.path_elements import (
     AlbumComponent,
     PathComponentFactory,
 )
-from omym.features.metadata.domain.track_metadata import TrackMetadata
+from omym.shared.track_metadata import TrackMetadata
 
 
 @pytest.fixture

--- a/tests/ui/cli/commands/test_executor.py
+++ b/tests/ui/cli/commands/test_executor.py
@@ -9,11 +9,11 @@ import pytest
 from pytest_mock import MockerFixture
 
 from omym.features.metadata import (
-    TrackMetadata,
-    ProcessResult,
-    LyricsProcessingResult,
     ArtworkProcessingResult,
+    LyricsProcessingResult,
+    ProcessResult,
 )
+from omym.shared import TrackMetadata
 from omym.application.services.organize_service import OrganizeRequest
 from omym.config.settings import UNPROCESSED_DIR_NAME
 from omym.ui.cli.args.options import OrganizeArgs

--- a/tests/ui/cli/display/test_preview.py
+++ b/tests/ui/cli/display/test_preview.py
@@ -10,12 +10,12 @@ from pathlib import Path
 from typing import ClassVar
 from pytest_mock import MockerFixture
 
-from omym.features.metadata import TrackMetadata
 from omym.features.metadata import (
     ArtworkProcessingResult,
     LyricsProcessingResult,
     ProcessResult,
 )
+from omym.shared import TrackMetadata
 from omym.ui.cli.display.preview import PreviewDisplay
 
 

--- a/tests/ui/cli/display/test_progress.py
+++ b/tests/ui/cli/display/test_progress.py
@@ -7,8 +7,9 @@ import pytest
 from pytest_mock import MockerFixture
 
 from typing import Callable
-from omym.features.metadata import TrackMetadata
+
 from omym.features.metadata import ProcessResult
+from omym.shared import TrackMetadata
 from omym.ui.cli.display.progress import ProgressDisplay, ProcessorWithProgress
 from omym.application.services.organize_service import OrganizeRequest
 from omym.platform.logging import logger

--- a/tests/ui/cli/display/test_result.py
+++ b/tests/ui/cli/display/test_result.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import pytest
 from pytest_mock import MockerFixture
 
-from omym.features.metadata import ProcessResult, TrackMetadata
+from omym.features.metadata import ProcessResult
+from omym.shared import TrackMetadata
 from omym.ui.cli.display.result import ResultDisplay
 from omym.ui.cli.models import UnprocessedSummary
 

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from omym.features.metadata import ProcessResult
-from omym.features.metadata import TrackMetadata
+from omym.shared import TrackMetadata
 from omym.features.restoration.domain.models import (
     CollisionPolicy,
     RestorePlanItem,


### PR DESCRIPTION
## Summary
- move the TrackMetadata dataclass into the shared package and expose it via omym.shared
- update metadata and path features along with tests to import the shared TrackMetadata

## Testing
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68dffeebca3c832a860168f7bf6c83b2