### PR TITLE
Introduce filesystem port for metadata use cases

### DIFF
--- a/src/omym/application/services/organize_service.py
+++ b/src/omym/application/services/organize_service.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Callable, final
 
 from omym.features.metadata import MusicProcessor, ProcessResult
+from omym.features.metadata.adapters import LocalFilesystemAdapter
 from omym.platform.db.daos.maintenance_dao import MaintenanceDAO
 from omym.platform.logging import logger
 
@@ -50,7 +51,11 @@ class OrganizeMusicService:
         Returns:
             Configured ``MusicProcessor`` instance.
         """
-        processor = MusicProcessor(base_path=request.base_path, dry_run=request.dry_run)
+        processor = MusicProcessor(
+            base_path=request.base_path,
+            dry_run=request.dry_run,
+            filesystem=LocalFilesystemAdapter(),
+        )
 
         # Optionally clear artist cache; continue on recognized transient errors.
         if request.clear_artist_cache and hasattr(processor, "artist_dao"):

--- a/src/omym/features/metadata/__init__.py
+++ b/src/omym/features/metadata/__init__.py
@@ -18,6 +18,7 @@ from .usecases.processing_types import (
 from .usecases.ports import (
     ArtistCachePort,
     DatabaseManagerPort,
+    FilesystemPort,
     ProcessingAfterPort,
     ProcessingBeforePort,
 )
@@ -37,4 +38,5 @@ __all__ = [
     "ProcessingBeforePort",
     "ProcessingAfterPort",
     "ArtistCachePort",
+    "FilesystemPort",
 ]

--- a/src/omym/features/metadata/adapters/__init__.py
+++ b/src/omym/features/metadata/adapters/__init__.py
@@ -1,0 +1,7 @@
+"""src/omym/features/metadata/adapters/__init__.py
+What: Package marker for metadata adapters.
+Why: Allow adapter modules to live alongside use cases with a clear namespace."""
+
+from .filesystem_adapter import LocalFilesystemAdapter
+
+__all__ = ["LocalFilesystemAdapter"]

--- a/src/omym/features/metadata/adapters/filesystem_adapter.py
+++ b/src/omym/features/metadata/adapters/filesystem_adapter.py
@@ -1,0 +1,23 @@
+"""src/omym/features/metadata/adapters/filesystem_adapter.py
+What: Adapter implementing FilesystemPort on top of platform helpers.
+Why: Keep filesystem I/O in adapters while use cases target abstractions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omym.features.metadata.usecases.ports import FilesystemPort
+from omym.platform.filesystem import ensure_parent_directory, remove_empty_directories
+
+
+class LocalFilesystemAdapter(FilesystemPort):
+    """Adapter delegating filesystem helpers to the shared platform module."""
+
+    def ensure_parent_directory(self, path: Path) -> Path:
+        return ensure_parent_directory(path)
+
+    def remove_empty_directories(self, directory: Path) -> None:
+        remove_empty_directories(directory)
+
+
+__all__ = ["LocalFilesystemAdapter"]

--- a/src/omym/features/metadata/usecases/directory_runner.py
+++ b/src/omym/features/metadata/usecases/directory_runner.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Protocol
 
 from omym.features.path.usecases.renamer import DirectoryGenerator, FileNameGenerator
-from omym.platform.filesystem import remove_empty_directories
 
 from .processing_types import (
     DirectoryRollbackError,
@@ -23,7 +22,7 @@ from .processing_types import (
 )
 from .extraction.romanization import RomanizationCoordinator
 from .extraction.track_metadata_extractor import MetadataExtractor
-from .ports import DatabaseManagerPort
+from .ports import DatabaseManagerPort, FilesystemPort
 from omym.shared.track_metadata import TrackMetadata
 
 
@@ -34,6 +33,7 @@ class ProcessorLike(Protocol):
     dry_run: bool
     db_manager: DatabaseManagerPort
     directory_generator: DirectoryGenerator
+    filesystem: FilesystemPort
     SUPPORTED_EXTENSIONS: set[str]
 
     def log_processing(
@@ -191,7 +191,7 @@ def run_directory_processing(
                 progress_callback(processed_count, total_files, current_file)
 
         if not processor.dry_run:
-            remove_empty_directories(directory)
+            processor.filesystem.remove_empty_directories(directory)
             conn.commit()
 
         summary_extra = stats.summary_extra()

--- a/src/omym/features/metadata/usecases/file_operations.py
+++ b/src/omym/features/metadata/usecases/file_operations.py
@@ -14,11 +14,11 @@ from pathlib import Path
 
 from omym.config.settings import FILE_HASH_CHUNK_SIZE
 from omym.features.path.usecases.renamer import DirectoryGenerator, FileNameGenerator
-from omym.platform.filesystem import ensure_parent_directory
 from omym.platform.logging import logger
 
 from .associated_assets import ProcessLogger
 from .processing_types import ProcessingEvent
+from .ports import FilesystemPort
 from omym.shared.track_metadata import TrackMetadata
 
 
@@ -85,6 +85,7 @@ def move_file(
     dest_path: Path,
     *,
     log: ProcessLogger,
+    filesystem: FilesystemPort,
     process_id: str | None = None,
     sequence: int | None = None,
     total: int | None = None,
@@ -93,7 +94,7 @@ def move_file(
 ) -> None:
     """Move a file from the source path to the target path."""
 
-    _ = ensure_parent_directory(dest_path)
+    _ = filesystem.ensure_parent_directory(dest_path)
     log(
         logging.INFO,
         ProcessingEvent.FILE_MOVE,

--- a/src/omym/features/metadata/usecases/music_file_processor.py
+++ b/src/omym/features/metadata/usecases/music_file_processor.py
@@ -32,6 +32,7 @@ from omym.platform.logging import logger
 from omym.platform.musicbrainz.client import configure_romanization_cache
 
 from omym.shared.track_metadata import TrackMetadata
+from ..adapters.filesystem_adapter import LocalFilesystemAdapter
 from .directory_runner import run_directory_processing
 from .file_runner import run_file_processing
 from .file_operations import calculate_file_hash, generate_target_path, move_file
@@ -43,6 +44,7 @@ from .unprocessed_cleanup import (
 from .ports import (
     ArtistCachePort,
     DatabaseManagerPort,
+    FilesystemPort,
     PreviewCachePort,
     ProcessingAfterPort,
     ProcessingBeforePort,
@@ -90,9 +92,12 @@ class MusicProcessor:
         after_gateway: ProcessingAfterPort | None = None,
         artist_cache: ArtistCachePort | None = None,
         preview_cache: PreviewCachePort | None = None,
+        filesystem: FilesystemPort | None = None,
     ) -> None:
         self.base_path = base_path
         self.dry_run = dry_run
+
+        self.filesystem: FilesystemPort = filesystem or LocalFilesystemAdapter()
 
         try:
             self.artist_name_preferences = load_artist_name_preferences()
@@ -178,6 +183,7 @@ class MusicProcessor:
             src_path,
             dest_path,
             log=self._log_processing,
+            filesystem=self.filesystem,
             process_id=process_id,
             sequence=sequence,
             total=total,
@@ -312,6 +318,7 @@ class MusicProcessor:
             remaining_candidates,
             unprocessed_dir_name=UNPROCESSED_DIR_NAME,
             dry_run=self.dry_run,
+            filesystem=self.filesystem,
         )
 
         return results

--- a/src/omym/features/metadata/usecases/ports.py
+++ b/src/omym/features/metadata/usecases/ports.py
@@ -108,3 +108,16 @@ class PreviewCachePort(Protocol):
     def delete_preview(self, file_hash: str) -> bool:
         """Remove a cached preview entry."""
         ...
+
+
+@runtime_checkable
+class FilesystemPort(Protocol):
+    """Port abstracting filesystem directory management helpers."""
+
+    def ensure_parent_directory(self, path: Path) -> Path:
+        """Ensure the parent directory for ``path`` exists and return it."""
+        ...
+
+    def remove_empty_directories(self, directory: Path) -> None:
+        """Recursively remove empty directories rooted at ``directory``."""
+        ...

--- a/src/omym/features/metadata/usecases/unprocessed_cleanup.py
+++ b/src/omym/features/metadata/usecases/unprocessed_cleanup.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from omym.platform.filesystem import ensure_parent_directory, remove_empty_directories
 from omym.platform.logging import logger
 
 from .processing_types import ProcessResult
+from .ports import FilesystemPort
 
 _LYRICS_COMPLETION_REASONS = {"already_at_target"}
 _ARTWORK_COMPLETION_REASONS = {"already_at_target"}
@@ -55,6 +55,7 @@ def relocate_unprocessed_files(
     *,
     unprocessed_dir_name: str,
     dry_run: bool,
+    filesystem: FilesystemPort,
 ) -> list[tuple[Path, Path]]:
     """Relocate surviving snapshot files under the unprocessed folder.
 
@@ -87,7 +88,7 @@ def relocate_unprocessed_files(
             )
             continue
 
-        _ = ensure_parent_directory(destination)
+        _ = filesystem.ensure_parent_directory(destination)
         target_path = _next_available_destination(destination)
         _ = original_path.replace(target_path)
         moves.append((original_path, target_path))
@@ -99,7 +100,7 @@ def relocate_unprocessed_files(
         )
 
     if moves:
-        remove_empty_directories(root)
+        filesystem.remove_empty_directories(root)
 
     return moves
 

--- a/tests/application/test_organize_service.py
+++ b/tests/application/test_organize_service.py
@@ -16,6 +16,7 @@ from omym.application.services.organize_service import (
     OrganizeRequest,
 )
 from omym.features.metadata import ProcessResult
+from omym.features.metadata.adapters import LocalFilesystemAdapter
 
 
 def test_build_processor_constructs_music_processor(mocker: MockerFixture) -> None:
@@ -35,6 +36,7 @@ def test_build_processor_constructs_music_processor(mocker: MockerFixture) -> No
     kwargs = mocked.call_args.kwargs
     assert kwargs.get("base_path") == Path(".")
     assert kwargs.get("dry_run") is True
+    assert isinstance(kwargs.get("filesystem"), LocalFilesystemAdapter)
 
 
 def test_build_processor_warns_and_continues_on_cache_clear_failure(

--- a/tests/features/metadata/test_music_file_processor.py
+++ b/tests/features/metadata/test_music_file_processor.py
@@ -733,8 +733,9 @@ class TestMusicProcessor:
             "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
-        _ = mocker.patch(
-            "omym.features.metadata.usecases.directory_runner.remove_empty_directories",
+        _ = mocker.patch.object(
+            processor.filesystem,
+            "remove_empty_directories",
             autospec=True,
         )
 

--- a/tests/features/metadata/test_music_file_processor.py
+++ b/tests/features/metadata/test_music_file_processor.py
@@ -18,6 +18,7 @@ from omym.features.metadata import (
     ProcessingEvent,
     ProcessResult,
 )
+from omym.features.metadata.usecases.ports import FilesystemPort
 from omym.shared import PreviewCacheEntry, TrackMetadata
 
 
@@ -714,6 +715,45 @@ class TestMusicProcessor:
         }
         process_ids.discard(None)
         assert len(process_ids) == 1
+
+    def test_process_directory_passes_filesystem_port_to_cleanup(
+        self,
+        mocker: MockerFixture,
+        processor: MusicProcessor,
+        tmp_path: Path,
+    ) -> None:
+        """The processor should wire its filesystem port into relocation helpers."""
+
+        filesystem = mocker.create_autospec(FilesystemPort, instance=True)
+        processor.filesystem = filesystem
+
+        remaining = {tmp_path / "unprocessed" / "leftover.txt"}
+        _ = mocker.patch(
+            "omym.features.metadata.usecases.music_file_processor.snapshot_unprocessed_candidates",
+            return_value=remaining,
+        )
+        _ = mocker.patch(
+            "omym.features.metadata.usecases.music_file_processor.run_directory_processing",
+            return_value=[],
+        )
+        _ = mocker.patch(
+            "omym.features.metadata.usecases.music_file_processor.calculate_pending_unprocessed",
+            return_value=remaining,
+        )
+        relocate_mock = mocker.patch(
+            "omym.features.metadata.usecases.music_file_processor.relocate_unprocessed_files",
+            return_value=[],
+        )
+
+        _ = processor.process_directory(tmp_path)
+
+        relocate_mock.assert_called_once_with(
+            tmp_path,
+            remaining,
+            unprocessed_dir_name=UNPROCESSED_DIR_NAME,
+            dry_run=processor.dry_run,
+            filesystem=filesystem,
+        )
 
     def test_process_directory_rollback_failure_logs_and_raises(
         self,


### PR DESCRIPTION
## Summary
- add a FilesystemPort to metadata use case ports so directory and relocation helpers no longer import platform filesystem helpers directly
- provide a LocalFilesystemAdapter that wraps the shared filesystem module and inject it through MusicProcessor construction in the organize service
- update metadata tests to exercise the new port wiring and ensure filesystem cleanup still runs

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68e03ea2ec8c832aa562bfb05cc7e2bf