### PR TITLE
Handle sanitization failures outside the path domain

### DIFF
--- a/src/omym/features/metadata/usecases/file_operations.py
+++ b/src/omym/features/metadata/usecases/file_operations.py
@@ -1,3 +1,7 @@
+# Path: `src/omym/features/metadata/usecases/file_operations.py`
+# Summary: File hashing, target path derivation, and move orchestration helpers.
+# Why: Shield orchestration from filesystem details while logging sanitization issues.
+
 """Where: src/omym/features/metadata/usecases/file_operations.py
 What: File movement helpers and target-path generation for music assets.
 Why: Separate low-level filesystem handling from MusicProcessor orchestration.
@@ -13,7 +17,11 @@ import shutil
 from pathlib import Path
 
 from omym.config.settings import FILE_HASH_CHUNK_SIZE
-from omym.features.path.usecases.renamer import DirectoryGenerator, FileNameGenerator
+from omym.features.path import (
+    DirectoryGenerator,
+    FileNameGenerator,
+    SanitizerError,
+)
 from omym.platform.logging import logger
 
 from .associated_assets import ProcessLogger
@@ -72,6 +80,9 @@ def generate_target_path(
         file_name = file_name_generator.generate(metadata)
         if not dir_path or not file_name:
             return None
+    except SanitizerError as exc:
+        logger.error("Sanitization failed while generating target path: %s", exc)
+        return None
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.error("Error generating target path: %s", exc)
         return None

--- a/src/omym/features/path/__init__.py
+++ b/src/omym/features/path/__init__.py
@@ -1,13 +1,18 @@
+# Path: `src/omym/features/path/__init__.py`
+# Summary: Export path feature domain and use case symbols.
+# Why: Provide a stable import surface for adapters and tests.
+
 """Public API for the path feature (domain + use cases)."""
 
 from omym.shared.path_components import ComponentValue
 
-from .domain.sanitizer import Sanitizer
+from .domain.sanitizer import Sanitizer, SanitizerError
 from .domain.path_elements import (
-    PathComponent,
-    PathComponentFactory,
     AlbumArtistComponent,
     AlbumComponent,
+    PathComponent,
+    PathComponentFactory,
+    UnknownPathComponentError,
 )
 from .usecases.renamer import (
     ArtistIdGenerator,
@@ -25,11 +30,13 @@ from .usecases.path_generator import PathGenerator, PathInfo
 
 __all__ = [
     "Sanitizer",
+    "SanitizerError",
     "ComponentValue",
     "PathComponent",
     "PathComponentFactory",
     "AlbumArtistComponent",
     "AlbumComponent",
+    "UnknownPathComponentError",
     "ArtistCacheWriter",
     "ArtistIdGenerator",
     "CachedArtistIdGenerator",

--- a/src/omym/features/path/domain/sanitizer.py
+++ b/src/omym/features/path/domain/sanitizer.py
@@ -1,11 +1,16 @@
+# Path: `src/omym/features/path/domain/sanitizer.py`
+# Summary: Pure sanitization helpers for file and directory components.
+# Why: Keep normalization logic in the domain without side effects like logging.
+
 """File and path name sanitization functionality."""
 
 import re
-from pathlib import Path
-from typing import final, ClassVar
 import unicodedata
+from pathlib import Path
+from typing import ClassVar, final
 
-from omym.platform.logging import logger
+class SanitizerError(RuntimeError):
+    """Raised when sanitization cannot complete successfully."""
 
 
 @final
@@ -86,7 +91,7 @@ class Sanitizer:
                 - Empty string if input is None or contains only special characters
 
         Raises:
-            Exception: If string sanitization fails for any reason.
+            SanitizerError: If string sanitization fails for any reason.
         """
         if not text:
             return ""
@@ -121,9 +126,8 @@ class Sanitizer:
 
             return text + extension
 
-        except Exception as e:
-            logger.error("Failed to sanitize string '%s': %s", text, e)
-            raise
+        except Exception as error:  # pragma: no cover - defensive: unexpected codec failures
+            raise SanitizerError("String sanitization failed") from error
 
     @classmethod
     def sanitize_artist_name(cls, artist_name: str | None) -> str:
@@ -186,7 +190,7 @@ class Sanitizer:
                 - File extension is preserved for the last component
 
         Raises:
-            Exception: If path sanitization fails for any reason.
+            SanitizerError: If path sanitization fails for any reason.
         """
         try:
             parts = list(path.parts)
@@ -217,9 +221,8 @@ class Sanitizer:
 
             return result
 
-        except Exception as e:
-            logger.error("Failed to sanitize path '%s': %s", path, e)
-            raise
+        except Exception as error:  # pragma: no cover - defensive: unexpected path failures
+            raise SanitizerError("Path sanitization failed") from error
 
     @classmethod
     def sanitize_title(cls, title: str | None) -> str:

--- a/src/omym/features/path/usecases/path_generator.py
+++ b/src/omym/features/path/usecases/path_generator.py
@@ -1,9 +1,8 @@
-"""Path generation use cases.
+# Path: `src/omym/features/path/usecases/path_generator.py`
+# Summary: Build relative library paths from filter projections or grouped metadata.
+# Why: Keep logging in the use case layer while domain components remain pure.
 
-Where: features/path/usecases.
-What: Assemble relative library paths from filter hierarchies or grouped metadata.
-Why: Expose a port-driven service so adapters can back persistence lookups.
-"""
+"""Path generation use cases."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/omym/features/path/usecases/renamer/directory.py
+++ b/src/omym/features/path/usecases/renamer/directory.py
@@ -1,9 +1,8 @@
-"""Directory generation helpers.
+# Path: `src/omym/features/path/usecases/renamer/directory.py`
+# Summary: Generate album directory structures with sanitized metadata.
+# Why: Catch sanitization errors at the use case boundary for proper logging.
 
-Where: features/path/usecases/renamer/directory.py
-What: Build album directory paths using sanitized metadata and year aggregation.
-Why: Keep album-level state isolated from higher-level orchestration.
-"""
+"""Directory generation helpers."""
 
 from __future__ import annotations
 
@@ -11,7 +10,7 @@ from pathlib import Path
 from typing import ClassVar, final
 
 from omym.shared.track_metadata import TrackMetadata
-from omym.features.path.domain.sanitizer import Sanitizer
+from omym.features.path.domain.sanitizer import Sanitizer, SanitizerError
 from omym.platform.logging import logger
 
 
@@ -67,6 +66,10 @@ class DirectoryGenerator:
             year_str = str(year).zfill(4)
 
             return Path(f"{album_artist}/{year_str}_{album}")
+
+        except SanitizerError as exc:
+            logger.error("Failed to sanitize directory metadata: %s", exc)
+            return Path("ERROR/0000_ERROR")
 
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.error("Failed to generate directory path: %s", exc)

--- a/src/omym/features/path/usecases/renamer/filename.py
+++ b/src/omym/features/path/usecases/renamer/filename.py
@@ -1,16 +1,15 @@
-"""File name generation helpers.
+# Path: `src/omym/features/path/usecases/renamer/filename.py`
+# Summary: Generate sanitized track file names with cached artist identifiers.
+# Why: Handle sanitization failures outside the domain layer and log them once.
 
-Where: features/path/usecases/renamer/filename.py
-What: Build canonical track file names using cached artist IDs and album context.
-Why: Allow reuse across use cases without depending on full processor orchestration.
-"""
+"""File name generation helpers."""
 
 from __future__ import annotations
 
 from typing import ClassVar, final
 
 from omym.shared.track_metadata import TrackMetadata
-from omym.features.path.domain.sanitizer import Sanitizer
+from omym.features.path.domain.sanitizer import Sanitizer, SanitizerError
 from omym.platform.logging import logger
 
 from .cached_artist_id import CachedArtistIdGenerator
@@ -98,6 +97,10 @@ class FileNameGenerator:
             if prefix:
                 return f"{prefix}_{track_num}_{title}_{artist_id}{extension}"
             return f"{track_num}_{title}_{artist_id}{extension}"
+
+        except SanitizerError as exc:
+            logger.error("Failed to sanitize file name metadata: %s", exc)
+            return f"ERROR_{metadata.file_extension}"
 
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.error("Failed to generate file name: %s", exc)

--- a/tests/features/metadata/usecases/test_file_operations.py
+++ b/tests/features/metadata/usecases/test_file_operations.py
@@ -1,3 +1,7 @@
+# Path: `tests/features/metadata/usecases/test_file_operations.py`
+# Summary: Validate hashing and target path generation behaviours in metadata use cases.
+# Why: Confirm sanitization failures propagate as logged errors instead of silent domain logs.
+
 """Where: tests/features/metadata/usecases/test_file_operations.py
 What: Regression tests for file hashing behaviour in metadata use cases.
 Why: Ensure hashing results stay stable when chunk sizing is configurable.
@@ -10,10 +14,13 @@ from __future__ import annotations
 import hashlib
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from omym.features.metadata.usecases import file_operations
+from omym.features.path import DirectoryGenerator, FileNameGenerator, SanitizerError
+from omym.shared.track_metadata import TrackMetadata
 
 
 def test_calculate_file_hash_matches_sha256(
@@ -31,3 +38,39 @@ def test_calculate_file_hash_matches_sha256(
     expected = hashlib.sha256(content).hexdigest()
 
     assert result == expected
+
+
+def test_generate_target_path_logs_sanitizer_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Sanitizer errors should be logged and result in a None target path."""
+
+    base_path = Path("/music")
+
+    class _FailingDirectoryGenerator:
+        def generate(self, _metadata: TrackMetadata) -> Path:
+            raise SanitizerError("directory sanitize failed")
+
+    class _StubFileNameGenerator:
+        def generate(self, _metadata: TrackMetadata) -> str:
+            return "ignored.mp3"
+
+    metadata = TrackMetadata(title="Song", album_artist="Artist")
+
+    caplog.set_level("ERROR")
+
+    result = file_operations.generate_target_path(
+        base_path,
+        directory_generator=cast(
+            DirectoryGenerator,
+            cast(object, _FailingDirectoryGenerator()),
+        ),
+        file_name_generator=cast(
+            FileNameGenerator,
+            cast(object, _StubFileNameGenerator()),
+        ),
+        metadata=metadata,
+    )
+
+    assert result is None
+    assert any("Sanitization failed" in message for message in caplog.messages)

--- a/tests/features/path/test_path_elements.py
+++ b/tests/features/path/test_path_elements.py
@@ -1,3 +1,7 @@
+# Path: `tests/features/path/test_path_elements.py`
+# Summary: Validate domain path component creation and sanitization behaviors.
+# Why: Ensure domain raises errors instead of logging directly.
+
 """Tests for path component functionality."""
 
 import pytest
@@ -6,10 +10,11 @@ from typing import override
 from omym.shared import ComponentValue as ExportedComponentValue
 from omym.shared.path_components import ComponentValue
 from omym.features.path.domain.path_elements import (
-    PathComponent,
     AlbumArtistComponent,
     AlbumComponent,
+    PathComponent,
     PathComponentFactory,
+    UnknownPathComponentError,
 )
 from omym.shared.track_metadata import TrackMetadata
 
@@ -136,8 +141,11 @@ def test_path_component_factory_create_album() -> None:
 
 def test_path_component_factory_create_unknown() -> None:
     """Test PathComponentFactory with unknown component type."""
-    component = PathComponentFactory.create("UnknownType", 1)
-    assert component is None
+
+    with pytest.raises(UnknownPathComponentError) as exc_info:
+        _ = PathComponentFactory.create("UnknownType", 1)
+
+    assert exc_info.value.component_type == "UnknownType"
 
 
 class MockPathComponent(PathComponent):

--- a/tests/features/path/test_path_generator.py
+++ b/tests/features/path/test_path_generator.py
@@ -1,3 +1,7 @@
+# Path: `tests/features/path/test_path_generator.py`
+# Summary: Verify path generation success and logging for failure scenarios.
+# Why: Confirm use cases surface domain issues without relying on domain logging.
+
 """Tests for the path generation system."""
 
 import sqlite3
@@ -279,14 +283,21 @@ def test_generate_paths_missing_values(path_generator: PathGenerator, filter_dao
     assert len(paths) == 0  # No paths generated due to missing album value
 
 
-def test_generate_paths_no_hierarchies(path_generator: PathGenerator) -> None:
+def test_generate_paths_no_hierarchies(
+    path_generator: PathGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test generating paths with no hierarchies.
 
     Args:
         path_generator: A test path generator.
+        caplog: Pytest capture fixture for log assertions.
     """
+
+    caplog.set_level("ERROR")
     paths = path_generator.generate_paths()
     assert len(paths) == 0
+    assert any("No hierarchies found" in message for message in caplog.messages)
 
 
 def test_generate_paths_with_injected_port(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- raise explicit sanitization and component factory errors from the path domain instead of logging directly
- handle and log those failures in the path renamer utilities and metadata file operations while exporting the new exceptions
- update path-related tests to assert the revised failure contracts and logging behavior

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68e042d89f8c832ab7123d268dad4b66