### PR TITLE
Refactor music processor wiring for injected dependencies

### DIFF
--- a/tests/application/test_organize_service.py
+++ b/tests/application/test_organize_service.py
@@ -22,8 +22,6 @@ from omym.features.metadata.adapters import LocalFilesystemAdapter
 def test_build_processor_constructs_music_processor(mocker: MockerFixture) -> None:
     """Service should construct a MusicProcessor with given parameters."""
 
-    service = OrganizeMusicService()
-
     mock_db_cls = mocker.patch(
         "omym.application.services.organize_service.DatabaseManager"
     )
@@ -65,6 +63,8 @@ def test_build_processor_constructs_music_processor(mocker: MockerFixture) -> No
         "omym.application.services.organize_service.MusicProcessor"
     )
 
+    service = OrganizeMusicService()
+
     req = OrganizeRequest(base_path=Path("."), dry_run=True)
     _ = service.build_processor(req)
 
@@ -92,8 +92,6 @@ def test_build_processor_warns_and_continues_on_cache_clear_failure(
     caplog: LogCaptureFixture, mocker: MockerFixture
 ) -> None:
     """build_processor should warn and continue when cache cleanup fails."""
-    service = OrganizeMusicService()
-
     processor_mock = mocker.Mock()
     conn = mocker.Mock(name="conn")
     db_manager = mocker.Mock(conn=conn)
@@ -136,6 +134,8 @@ def test_build_processor_warns_and_continues_on_cache_clear_failure(
     maintenance_instance.clear_all.side_effect = sqlite3.OperationalError(
         "maintenance clearing failed"
     )
+
+    service = OrganizeMusicService()
 
     caplog.set_level(logging.WARNING, logger="omym")
 

--- a/tests/application/test_organize_service_clear.py
+++ b/tests/application/test_organize_service_clear.py
@@ -14,8 +14,6 @@ from omym.application.services.organize_service import (
 
 def test_clear_cache_uses_maintenance_dao(mocker: MockerFixture) -> None:
     """When clear_cache=True, service should call MaintenanceDAO.clear_all()."""
-    service = OrganizeMusicService()
-
     db_manager = mocker.MagicMock()
     db_manager.conn = object()
     artist_cache = mocker.MagicMock()
@@ -57,6 +55,8 @@ def test_clear_cache_uses_maintenance_dao(mocker: MockerFixture) -> None:
     mocked_maint = mocker.patch("omym.application.services.organize_service.MaintenanceDAO")
     maint_instance = mocked_maint.return_value
 
+    service = OrganizeMusicService()
+
     req = OrganizeRequest(base_path=Path("."), dry_run=True, clear_cache=True)
     _ = service.build_processor(req)
 
@@ -73,8 +73,6 @@ def test_clear_cache_uses_maintenance_dao(mocker: MockerFixture) -> None:
 
 def test_clear_artist_cache_uses_artist_dao(mocker: MockerFixture) -> None:
     """When clear_artist_cache=True, service should call ArtistCacheDAO.clear_cache()."""
-    service = OrganizeMusicService()
-
     db_manager = mocker.MagicMock()
     db_manager.conn = object()
     artist_cache = mocker.MagicMock()
@@ -112,6 +110,8 @@ def test_clear_artist_cache_uses_artist_dao(mocker: MockerFixture) -> None:
         "omym.application.services.organize_service.MusicProcessor",
         side_effect=processor_factory,
     )
+
+    service = OrganizeMusicService()
 
     req = OrganizeRequest(base_path=Path("."), dry_run=True, clear_artist_cache=True)
     _ = service.build_processor(req)

--- a/tests/application/test_organize_service_clear.py
+++ b/tests/application/test_organize_service_clear.py
@@ -16,12 +16,42 @@ def test_clear_cache_uses_maintenance_dao(mocker: MockerFixture) -> None:
     """When clear_cache=True, service should call MaintenanceDAO.clear_all()."""
     service = OrganizeMusicService()
 
-    # Patch MusicProcessor to expose a db_manager with a connection
-    mocked_proc = mocker.patch("omym.application.services.organize_service.MusicProcessor")
-    proc_instance = mocked_proc.return_value
     db_manager = mocker.MagicMock()
-    db_manager.conn = object()  # sentinel non-None
-    proc_instance.db_manager = db_manager
+    db_manager.conn = object()
+    artist_cache = mocker.MagicMock()
+
+    mocked_db = mocker.patch(
+        "omym.application.services.organize_service.DatabaseManager",
+        return_value=db_manager,
+    )
+    mocked_before = mocker.patch(
+        "omym.application.services.organize_service.ProcessingBeforeDAO"
+    )
+    mocked_after = mocker.patch(
+        "omym.application.services.organize_service.ProcessingAfterDAO"
+    )
+    mocked_preview = mocker.patch(
+        "omym.application.services.organize_service.ProcessingPreviewDAO"
+    )
+    mocked_artist = mocker.patch(
+        "omym.application.services.organize_service.ArtistCacheDAO"
+    )
+    mocked_dry_run = mocker.patch(
+        "omym.application.services.organize_service.DryRunArtistCacheAdapter",
+        return_value=artist_cache,
+    )
+
+    proc_instance = mocker.MagicMock()
+
+    def processor_factory(*_: object, **kwargs: object) -> object:
+        proc_instance.db_manager = kwargs["db_manager"]
+        proc_instance.artist_dao = kwargs["artist_cache"]
+        return proc_instance
+
+    mocked_proc = mocker.patch(
+        "omym.application.services.organize_service.MusicProcessor",
+        side_effect=processor_factory,
+    )
 
     # Patch MaintenanceDAO
     mocked_maint = mocker.patch("omym.application.services.organize_service.MaintenanceDAO")
@@ -30,22 +60,61 @@ def test_clear_cache_uses_maintenance_dao(mocker: MockerFixture) -> None:
     req = OrganizeRequest(base_path=Path("."), dry_run=True, clear_cache=True)
     _ = service.build_processor(req)
 
-    mocked_maint.assert_called_once()
-    maint_instance.clear_all.assert_called_once()
+    _ = mocked_db.assert_called_once_with()
+    _ = mocked_before.assert_called_once()
+    _ = mocked_after.assert_called_once()
+    _ = mocked_preview.assert_called_once()
+    _ = mocked_artist.assert_called_once()
+    _ = mocked_dry_run.assert_called_once()
+    _ = mocked_proc.assert_called_once()
+    _ = mocked_maint.assert_called_once()
+    _ = maint_instance.clear_all.assert_called_once()
 
 
 def test_clear_artist_cache_uses_artist_dao(mocker: MockerFixture) -> None:
     """When clear_artist_cache=True, service should call ArtistCacheDAO.clear_cache()."""
     service = OrganizeMusicService()
 
-    mocked_proc = mocker.patch("omym.application.services.organize_service.MusicProcessor")
-    proc_instance = mocked_proc.return_value
-    # Provide artist_dao with clear_cache()
-    artist_dao = mocker.MagicMock()
-    proc_instance.artist_dao = artist_dao
+    db_manager = mocker.MagicMock()
+    db_manager.conn = object()
+    artist_cache = mocker.MagicMock()
+
+    _ = mocker.patch(
+        "omym.application.services.organize_service.DatabaseManager",
+        return_value=db_manager,
+    )
+    _ = mocker.patch(
+        "omym.application.services.organize_service.ProcessingBeforeDAO"
+    )
+    _ = mocker.patch(
+        "omym.application.services.organize_service.ProcessingAfterDAO"
+    )
+    _ = mocker.patch(
+        "omym.application.services.organize_service.ProcessingPreviewDAO"
+    )
+    _ = mocker.patch(
+        "omym.application.services.organize_service.ArtistCacheDAO",
+        return_value=artist_cache,
+    )
+    _ = mocker.patch(
+        "omym.application.services.organize_service.DryRunArtistCacheAdapter",
+        return_value=artist_cache,
+    )
+
+    proc_instance = mocker.MagicMock()
+
+    def processor_factory(*_: object, **kwargs: object) -> object:
+        proc_instance.db_manager = kwargs["db_manager"]
+        proc_instance.artist_dao = kwargs["artist_cache"]
+        return proc_instance
+
+    _ = mocker.patch(
+        "omym.application.services.organize_service.MusicProcessor",
+        side_effect=processor_factory,
+    )
 
     req = OrganizeRequest(base_path=Path("."), dry_run=True, clear_artist_cache=True)
     _ = service.build_processor(req)
 
-    artist_dao.clear_cache.assert_called_once()
+    _ = artist_cache.clear_cache.assert_called_once()
 

--- a/tests/ui/cli/commands/test_executor.py
+++ b/tests/ui/cli/commands/test_executor.py
@@ -73,8 +73,7 @@ def mock_processor(mocker: MockerFixture) -> MagicMock:
     Returns:
         MagicMock: Mock processor instance.
     """
-    mock = mocker.patch("omym.application.services.organize_service.MusicProcessor", autospec=True)
-    mock_instance = mock.return_value
+    mock_instance = mocker.MagicMock()
     mock_instance.base_path = Path("output")
 
     # Setup mock process_file method
@@ -99,6 +98,11 @@ def mock_processor(mocker: MockerFixture) -> MagicMock:
         artist_id=None,
     )
 
+    _ = mocker.patch(
+        "omym.application.services.organize_service.OrganizeMusicService.build_processor",
+        return_value=mock_instance,
+    )
+
     return mock_instance
 
 
@@ -121,12 +125,12 @@ def test_file_command(test_args: OrganizeArgs, mock_processor: MagicMock, mocker
 
     # Verify
     assert len(results) == 1
-    mock_processor.process_file.assert_called_once_with(test_args.music_path)
-    mock_result.return_value.show_results.assert_called_once()
-    mock_result.return_value.show_unprocessed_summary.assert_called_once()
+    _ = mock_processor.process_file.assert_called_once_with(test_args.music_path)
+    _ = mock_result.return_value.show_results.assert_called_once()
+    _ = mock_result.return_value.show_unprocessed_summary.assert_called_once()
     summary_arg = mock_result.return_value.show_unprocessed_summary.call_args.args[0]
     assert summary_arg.total == 0
-    mock_preview.return_value.show_preview.assert_not_called()
+    _ = mock_preview.return_value.show_preview.assert_not_called()
 
 
 def test_directory_command(test_args: OrganizeArgs, mock_processor: MagicMock, mocker: MockerFixture) -> None:
@@ -160,11 +164,11 @@ def test_directory_command(test_args: OrganizeArgs, mock_processor: MagicMock, m
     assert args[2] == test_args.music_path
     assert kwargs.get("interactive") == test_args.interactive
     assert kwargs.get("processor") is mock_processor
-    mock_result.return_value.show_results.assert_called_once()
-    mock_result.return_value.show_unprocessed_summary.assert_called_once()
+    _ = mock_result.return_value.show_results.assert_called_once()
+    _ = mock_result.return_value.show_unprocessed_summary.assert_called_once()
     summary_arg = mock_result.return_value.show_unprocessed_summary.call_args.args[0]
     assert summary_arg.total == 0
-    mock_preview.return_value.show_preview.assert_not_called()
+    _ = mock_preview.return_value.show_preview.assert_not_called()
 
 
 def test_dry_run_mode(
@@ -193,9 +197,9 @@ def test_dry_run_mode(
 
     # Verify
     assert len(results) == 1
-    mock_preview.return_value.show_preview.assert_called_once()
-    mock_result.return_value.show_results.assert_not_called()
-    mock_result.return_value.show_unprocessed_summary.assert_called_once()
+    _ = mock_preview.return_value.show_preview.assert_called_once()
+    _ = mock_result.return_value.show_results.assert_not_called()
+    _ = mock_result.return_value.show_unprocessed_summary.assert_called_once()
     summary_arg = mock_result.return_value.show_unprocessed_summary.call_args.args[0]
     assert summary_arg.total == 0
 

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -46,8 +46,7 @@ def mock_processor(mocker: MockerFixture) -> MagicMock:
     Returns:
         MagicMock: Mock processor instance.
     """
-    mock = mocker.patch("omym.application.services.organize_service.MusicProcessor")
-    mock_instance = mock.return_value
+    mock_instance = mocker.MagicMock()
 
     # Setup mock process_file method
     metadata = TrackMetadata(
@@ -69,6 +68,11 @@ def mock_processor(mocker: MockerFixture) -> MagicMock:
         success=True,
         metadata=metadata,
         artist_id=None,
+    )
+
+    _ = mocker.patch(
+        "omym.application.services.organize_service.OrganizeMusicService.build_processor",
+        return_value=mock_instance,
     )
 
     return mock_instance
@@ -105,9 +109,9 @@ def test_process_single_file(test_dir: Path, mock_processor: MagicMock, mocker: 
     CommandProcessor.process_command(['organize', str(test_file)])
 
     # Verify
-    mock_processor.process_file.assert_called_once_with(test_file)
-    mock_result.return_value.show_results.assert_called_once()
-    mock_preview.return_value.show_preview.assert_not_called()
+    _ = mock_processor.process_file.assert_called_once_with(test_file)
+    _ = mock_result.return_value.show_results.assert_called_once()
+    _ = mock_preview.return_value.show_preview.assert_not_called()
 
 
 def test_process_directory(test_dir: Path, mock_processor: MagicMock, mocker: MockerFixture) -> None:
@@ -136,8 +140,8 @@ def test_process_directory(test_dir: Path, mock_processor: MagicMock, mocker: Mo
     # Third positional arg is directory
     assert args[2] == test_dir
     assert kwargs.get("interactive") is False
-    mock_result.return_value.show_results.assert_called_once()
-    mock_preview.return_value.show_preview.assert_not_called()
+    _ = mock_result.return_value.show_results.assert_called_once()
+    _ = mock_preview.return_value.show_preview.assert_not_called()
 
 
 def test_plan_subcommand(test_dir: Path, mocker: MockerFixture) -> None:
@@ -156,8 +160,8 @@ def test_plan_subcommand(test_dir: Path, mocker: MockerFixture) -> None:
     CommandProcessor.process_command(['plan', str(test_dir)])
 
     # Verify
-    mock_preview.return_value.show_preview.assert_called_once()
-    mock_result.return_value.show_results.assert_not_called()
+    _ = mock_preview.return_value.show_preview.assert_called_once()
+    _ = mock_result.return_value.show_results.assert_not_called()
 
 
 def test_error_handling(


### PR DESCRIPTION
## Summary
- require explicit dependency injection for `MusicProcessor` instead of instantiating DAOs internally
- assemble concrete database and cache adapters inside `OrganizeMusicService` while preserving cache-clearing behaviour
- update metadata and CLI test suites to exercise the new wiring and dry-run pathways

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68e04b0ec9c4832a874d493459eac3b8