### PR TITLE
Refactor metadata use case packages

### DIFF
--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -8,6 +8,10 @@ review_cadence: quarterly
   - [`omym/features/`](../src/omym/features): Feature-oriented packages combining domain, use case, and adapter slices. Current features: `metadata`, `organization`, `path`, `restoration`.
     - `domain/`: pure business rules for the feature.
     - `usecases/`: application services, commands, queries, and port protocols.
+        - `processing/`: directory and file orchestration plus shared flow types.
+        - `assets/`: lyrics and artwork asset discovery, logging, and summarisation.
+        - `file_management/`: file hashing, duplicate handling, and target path utilities.
+        - `cleanup/`: post-run lifecycle helpers for unprocessed material.
     - `adapters/`: infrastructure implementations (DB, filesystem, external APIs) that fulfil ports.
   - [`omym/platform/`](../src/omym/platform): Cross-cutting technical services—database manager, filesystem primitives, logging bootstrap, configuration providers, MusicBrainz HTTP client.
     - `musicbrainz/`: split into focused modules (`http_client`, `rate_limit`, `romanization`, `cache`, `user_agent`) with `client.py` acting as the public façade.

--- a/src/omym/features/metadata/__init__.py
+++ b/src/omym/features/metadata/__init__.py
@@ -6,8 +6,8 @@
 
 from omym.shared.track_metadata import TrackMetadata
 from .usecases.extraction import ArtistRomanizer, MetadataExtractor
-from .usecases.music_file_processor import MusicProcessor
-from .usecases.processing_types import (
+from .usecases.processing.music_file_processor import MusicProcessor
+from .usecases.processing.processing_types import (
     ArtworkProcessingResult,
     DirectoryRollbackError,
     LyricsProcessingResult,

--- a/src/omym/features/metadata/usecases/__init__.py
+++ b/src/omym/features/metadata/usecases/__init__.py
@@ -1,0 +1,20 @@
+"""
+/*
+Path: src/omym/features/metadata/usecases/__init__.py
+Summary: Package exports for metadata use case helpers.
+Why: Provide a stable namespace after reorganising helper modules.
+*/
+"""
+
+"""Use case helpers for metadata processing flows."""
+
+from . import assets, cleanup, extraction, file_management, ports, processing
+
+__all__ = [
+    "assets",
+    "cleanup",
+    "extraction",
+    "file_management",
+    "ports",
+    "processing",
+]

--- a/src/omym/features/metadata/usecases/assets/__init__.py
+++ b/src/omym/features/metadata/usecases/assets/__init__.py
@@ -1,0 +1,31 @@
+"""
+/*
+Path: src/omym/features/metadata/usecases/assets/__init__.py
+Summary: Asset helper package marker and exports.
+Why: Group artwork and lyric asset utilities for clarity.
+*/
+"""
+
+"""Asset discovery and logging helpers for metadata processing."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from . import asset_detection, asset_logging, artwork_assets, associated_assets, lyrics_assets
+
+__all__ = [
+    "asset_detection",
+    "asset_logging",
+    "artwork_assets",
+    "associated_assets",
+    "lyrics_assets",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import asset helper modules to avoid circular imports."""
+
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/omym/features/metadata/usecases/assets/artwork_assets.py
+++ b/src/omym/features/metadata/usecases/assets/artwork_assets.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/artwork_assets.py
+"""src/omym/features/metadata/usecases/assets/artwork_assets.py
 Where: Metadata feature usecases layer.
 What: Handle movement and summarisation of artwork files for tracks.
 Why: Separate artwork-specific behaviour from the core processor.
@@ -18,7 +18,7 @@ from collections.abc import Iterable
 from omym.platform.filesystem import ensure_parent_directory
 
 from .asset_logging import ProcessLogger
-from .processing_types import ArtworkProcessingResult, ProcessingEvent
+from ..processing.processing_types import ArtworkProcessingResult, ProcessingEvent
 
 
 def process_artwork(

--- a/src/omym/features/metadata/usecases/assets/asset_detection.py
+++ b/src/omym/features/metadata/usecases/assets/asset_detection.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/asset_detection.py
+"""src/omym/features/metadata/usecases/assets/asset_detection.py
 What: Detect nearby lyrics or artwork assets for a track file.
 Why: Share discovery logic between file processing flows.
 """

--- a/src/omym/features/metadata/usecases/assets/asset_logging.py
+++ b/src/omym/features/metadata/usecases/assets/asset_logging.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/asset_logging.py
+"""src/omym/features/metadata/usecases/assets/asset_logging.py
 What: Shared protocol definition for structured processing log callbacks.
 Why: Allow asset helpers to depend on a minimal logging contract.
 """
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from .processing_types import ProcessingEvent
+from ..processing.processing_types import ProcessingEvent
 
 
 class ProcessLogger(Protocol):

--- a/src/omym/features/metadata/usecases/assets/associated_assets.py
+++ b/src/omym/features/metadata/usecases/assets/associated_assets.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/associated_assets.py
+"""src/omym/features/metadata/usecases/assets/associated_assets.py
 What: Convenience re-export for asset detection and handling helpers.
 Why: Preserve existing import surface while splitting hefty modules.
 """

--- a/src/omym/features/metadata/usecases/assets/lyrics_assets.py
+++ b/src/omym/features/metadata/usecases/assets/lyrics_assets.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/lyrics_assets.py
+"""src/omym/features/metadata/usecases/assets/lyrics_assets.py
 Where: Metadata feature usecases layer.
 What: Handle movement and summarisation of lyrics files tied to tracks.
 Why: Keep lyrics-specific side effects isolated from core processing logic.
@@ -17,7 +17,7 @@ from pathlib import Path
 from omym.platform.filesystem import ensure_parent_directory
 
 from .asset_logging import ProcessLogger
-from .processing_types import LyricsProcessingResult, ProcessingEvent
+from ..processing.processing_types import LyricsProcessingResult, ProcessingEvent
 
 
 def process_lyrics(

--- a/src/omym/features/metadata/usecases/cleanup/__init__.py
+++ b/src/omym/features/metadata/usecases/cleanup/__init__.py
@@ -1,0 +1,25 @@
+"""
+/*
+Path: src/omym/features/metadata/usecases/cleanup/__init__.py
+Summary: Cleanup helper package marker and exports.
+Why: Isolate lifecycle management utilities for metadata processing.
+*/
+"""
+
+"""Cleanup helpers for metadata processing workflows."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from . import unprocessed_cleanup
+
+__all__ = ["unprocessed_cleanup"]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import cleanup helpers to avoid circular imports."""
+
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/omym/features/metadata/usecases/cleanup/unprocessed_cleanup.py
+++ b/src/omym/features/metadata/usecases/cleanup/unprocessed_cleanup.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/unprocessed_cleanup.py
+"""src/omym/features/metadata/usecases/cleanup/unprocessed_cleanup.py
 Where: Metadata feature usecases layer.
 What: Utilities to relocate unprocessed files into a dedicated review folder.
 Why: Keep directory processors focused while centralising fallback clean-up logic.
@@ -15,8 +15,8 @@ from pathlib import Path
 
 from omym.platform.logging import logger
 
-from .processing_types import ProcessResult
-from .ports import FilesystemPort
+from ..processing.processing_types import ProcessResult
+from ..ports import FilesystemPort
 
 _LYRICS_COMPLETION_REASONS = {"already_at_target"}
 _ARTWORK_COMPLETION_REASONS = {"already_at_target"}

--- a/src/omym/features/metadata/usecases/file_management/__init__.py
+++ b/src/omym/features/metadata/usecases/file_management/__init__.py
@@ -1,0 +1,30 @@
+"""
+/*
+Path: src/omym/features/metadata/usecases/file_management/__init__.py
+Summary: File management helper package marker and exports.
+Why: Collect file handling utilities for reuse across processing flows.
+*/
+"""
+
+"""Shared file management utilities for metadata use cases."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from . import file_context, file_duplicate, file_operations, file_success
+
+__all__ = [
+    "file_context",
+    "file_duplicate",
+    "file_operations",
+    "file_success",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import file management helpers to avoid circular imports."""
+
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/omym/features/metadata/usecases/file_management/file_context.py
+++ b/src/omym/features/metadata/usecases/file_management/file_context.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/file_context.py
+"""src/omym/features/metadata/usecases/file_management/file_context.py
 What: Shared state container for per-file processing helpers.
 Why: Avoid long parameter lists when coordinating helper functions.
 """
@@ -12,7 +12,7 @@ from typing import Protocol, TYPE_CHECKING
 if TYPE_CHECKING:
     from omym.features.path.usecases.renamer import CachedArtistIdGenerator
 
-from .processing_types import (
+from ..processing.processing_types import (
     ArtworkProcessingResult,
     LyricsProcessingResult,
     ProcessingEvent,

--- a/src/omym/features/metadata/usecases/file_management/file_duplicate.py
+++ b/src/omym/features/metadata/usecases/file_management/file_duplicate.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/file_duplicate.py
+"""src/omym/features/metadata/usecases/file_management/file_duplicate.py
 What: Handle duplicate detection branch for file processing.
 Why: Keep the main runner concise by isolating duplicate logic.
 """
@@ -8,8 +8,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from .associated_assets import process_artwork, process_lyrics, summarize_artwork, summarize_lyrics
-from .processing_types import ProcessResult, ProcessingEvent
+from ..assets.associated_assets import process_artwork, process_lyrics, summarize_artwork, summarize_lyrics
+from ..processing.processing_types import ProcessResult, ProcessingEvent
 from .file_context import FileProcessingContext
 
 

--- a/src/omym/features/metadata/usecases/file_management/file_operations.py
+++ b/src/omym/features/metadata/usecases/file_management/file_operations.py
@@ -1,4 +1,4 @@
-"""Where: src/omym/features/metadata/usecases/file_operations.py
+"""Where: src/omym/features/metadata/usecases/file_management/file_operations.py
 What: File movement helpers and target-path generation for music assets.
 Why: Separate low-level filesystem handling from MusicProcessor orchestration.
 Assumptions: - Input paths reference regular files accessible on disk.
@@ -16,9 +16,9 @@ from omym.config.settings import FILE_HASH_CHUNK_SIZE
 from omym.features.path.usecases.renamer import DirectoryGenerator, FileNameGenerator
 from omym.platform.logging import logger
 
-from .associated_assets import ProcessLogger
-from .processing_types import ProcessingEvent
-from .ports import FilesystemPort
+from ..assets.associated_assets import ProcessLogger
+from ..processing.processing_types import ProcessingEvent
+from ..ports import FilesystemPort
 from omym.shared.track_metadata import TrackMetadata
 
 

--- a/src/omym/features/metadata/usecases/file_management/file_success.py
+++ b/src/omym/features/metadata/usecases/file_management/file_success.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/file_success.py
+"""src/omym/features/metadata/usecases/file_management/file_success.py
 What: Finalise successful processing of a track file.
 Why: Keep the main runner lean by extracting post-move handling.
 """
@@ -9,8 +9,8 @@ import logging
 from pathlib import Path
 
 from omym.shared.track_metadata import TrackMetadata
-from .associated_assets import process_artwork, process_lyrics, summarize_artwork, summarize_lyrics
-from .processing_types import ProcessResult, ProcessingEvent
+from ..assets.associated_assets import process_artwork, process_lyrics, summarize_artwork, summarize_lyrics
+from ..processing.processing_types import ProcessResult, ProcessingEvent
 from .file_context import FileProcessingContext
 
 

--- a/src/omym/features/metadata/usecases/processing/__init__.py
+++ b/src/omym/features/metadata/usecases/processing/__init__.py
@@ -1,0 +1,30 @@
+"""
+/*
+Path: src/omym/features/metadata/usecases/processing/__init__.py
+Summary: Processing orchestration package marker and exports.
+Why: Provide a clear namespace for music metadata processing workflows.
+*/
+"""
+
+"""Processing orchestration helpers for metadata use cases."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from . import directory_runner, file_runner, music_file_processor, processing_types
+
+__all__ = [
+    "directory_runner",
+    "file_runner",
+    "music_file_processor",
+    "processing_types",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import processing modules to avoid circular imports."""
+
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/omym/features/metadata/usecases/processing/directory_runner.py
+++ b/src/omym/features/metadata/usecases/processing/directory_runner.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/directory_runner.py
+"""src/omym/features/metadata/usecases/processing/directory_runner.py
 What: Shared implementation for directory-wide music processing.
 Why: Keep MusicProcessor slim while reusing robust directory orchestration logic.
 """
@@ -20,9 +20,9 @@ from .processing_types import (
     ProcessingEvent,
     ProcessingLogContext,
 )
-from .extraction.romanization import RomanizationCoordinator
-from .extraction.track_metadata_extractor import MetadataExtractor
-from .ports import DatabaseManagerPort, FilesystemPort
+from ..extraction.romanization import RomanizationCoordinator
+from ..extraction.track_metadata_extractor import MetadataExtractor
+from ..ports import DatabaseManagerPort, FilesystemPort
 from omym.shared.track_metadata import TrackMetadata
 
 

--- a/src/omym/features/metadata/usecases/processing/file_runner.py
+++ b/src/omym/features/metadata/usecases/processing/file_runner.py
@@ -1,5 +1,5 @@
 # /*
-# Where: features/metadata/usecases/file_runner.py
+# Where: features/metadata/usecases/processing/file_runner.py
 # What: Shared implementation for per-file music processing orchestration.
 # Why: Keep MusicProcessor lean by isolating procedural flow and duplicate handling.
 # Assumptions:
@@ -25,19 +25,19 @@ from omym.features.path.usecases.renamer import (
     FileNameGenerator,
 )
 
-from .asset_detection import find_associated_lyrics, resolve_directory_artwork
-from .file_context import FileProcessingContext
-from .file_duplicate import handle_duplicate
-from .file_success import complete_success
-from .ports import (
+from ..assets.asset_detection import find_associated_lyrics, resolve_directory_artwork
+from ..file_management.file_context import FileProcessingContext
+from ..file_management.file_duplicate import handle_duplicate
+from ..file_management.file_success import complete_success
+from ..ports import (
     ArtistCachePort,
     PreviewCachePort,
     ProcessingAfterPort,
     ProcessingBeforePort,
 )
 from .processing_types import ProcessResult, ProcessingEvent
-from .extraction.romanization import RomanizationCoordinator
-from .extraction.track_metadata_extractor import MetadataExtractor
+from ..extraction.romanization import RomanizationCoordinator
+from ..extraction.track_metadata_extractor import MetadataExtractor
 from omym.shared.track_metadata import TrackMetadata
 
 

--- a/src/omym/features/metadata/usecases/processing/music_file_processor.py
+++ b/src/omym/features/metadata/usecases/processing/music_file_processor.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/music_file_processor.py
+"""src/omym/features/metadata/usecases/processing/music_file_processor.py
 What: High-level coordinator that organises music files into the library structure.
 Why: Tie together metadata extraction, romanisation, persistence, and asset moves.
 """
@@ -32,16 +32,16 @@ from omym.platform.logging import logger
 from omym.platform.musicbrainz.client import configure_romanization_cache
 
 from omym.shared.track_metadata import TrackMetadata
-from ..adapters.filesystem_adapter import LocalFilesystemAdapter
+from ...adapters.filesystem_adapter import LocalFilesystemAdapter
 from .directory_runner import run_directory_processing
 from .file_runner import run_file_processing
-from .file_operations import calculate_file_hash, generate_target_path, move_file
-from .unprocessed_cleanup import (
+from ..file_management.file_operations import calculate_file_hash, generate_target_path, move_file
+from ..cleanup.unprocessed_cleanup import (
     calculate_pending_unprocessed,
     relocate_unprocessed_files,
     snapshot_unprocessed_candidates,
 )
-from .ports import (
+from ..ports import (
     ArtistCachePort,
     DatabaseManagerPort,
     FilesystemPort,
@@ -50,8 +50,8 @@ from .ports import (
     ProcessingBeforePort,
 )
 from .processing_types import ProcessingEvent
-from .extraction.artist_cache_adapter import DryRunArtistCacheAdapter
-from .extraction.romanization import RomanizationCoordinator
+from ..extraction.artist_cache_adapter import DryRunArtistCacheAdapter
+from ..extraction.romanization import RomanizationCoordinator
 
 if TYPE_CHECKING:
     from .processing_types import ProcessResult

--- a/src/omym/features/metadata/usecases/processing/processing_types.py
+++ b/src/omym/features/metadata/usecases/processing/processing_types.py
@@ -1,4 +1,4 @@
-"""src/omym/features/metadata/usecases/processing_types.py
+"""src/omym/features/metadata/usecases/processing/processing_types.py
 Where: Metadata feature usecases layer.
 What: Shared enums and dataclasses for music file processing flow.
 Why: Keep the core processor lean by centralising type definitions.

--- a/src/omym/ui/cli/commands/executor.py
+++ b/src/omym/ui/cli/commands/executor.py
@@ -15,7 +15,7 @@ from omym.ui.cli.display.preview import PreviewDisplay
 from omym.ui.cli.display.progress import ProgressDisplay
 from omym.ui.cli.display.result import ResultDisplay
 from omym.ui.cli.models import UnprocessedSummary
-from omym.features.metadata.usecases.unprocessed_cleanup import (
+from omym.features.metadata.usecases.cleanup.unprocessed_cleanup import (
     calculate_pending_unprocessed,
     snapshot_unprocessed_candidates,
 )

--- a/tests/features/metadata/test_file_runner_reorganize.py
+++ b/tests/features/metadata/test_file_runner_reorganize.py
@@ -30,7 +30,7 @@ from omym.shared import PreviewCacheEntry, TrackMetadata
 from pytest_mock import MockerFixture
 
 from omym.features.metadata.usecases.extraction.romanization import RomanizationCoordinator
-from omym.features.metadata.usecases.file_runner import run_file_processing
+from omym.features.metadata.usecases.processing.file_runner import run_file_processing
 
 
 class _StubBeforeDAO(ProcessingBeforePort):
@@ -301,7 +301,7 @@ def test_reorganize_moves_when_target_changes(tmp_path: Path, mocker: MockerFixt
     )
 
     _ = mocker.patch(
-        "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+        "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
         return_value=metadata,
     )
 

--- a/tests/features/metadata/test_lyrics_assets.py
+++ b/tests/features/metadata/test_lyrics_assets.py
@@ -2,9 +2,9 @@
 
 from pathlib import Path
 
-from omym.features.metadata.usecases.asset_logging import ProcessLogger
-from omym.features.metadata.usecases.lyrics_assets import process_lyrics, summarize_lyrics
-from omym.features.metadata.usecases.processing_types import LyricsProcessingResult, ProcessingEvent
+from omym.features.metadata.usecases.assets.asset_logging import ProcessLogger
+from omym.features.metadata.usecases.assets.lyrics_assets import process_lyrics, summarize_lyrics
+from omym.features.metadata.usecases.processing.processing_types import LyricsProcessingResult, ProcessingEvent
 
 
 class DummyLogger(ProcessLogger):

--- a/tests/features/metadata/test_music_file_processor.py
+++ b/tests/features/metadata/test_music_file_processor.py
@@ -66,14 +66,14 @@ def processor(mocker: MockerFixture, tmp_path: Path, file_hash: str) -> MusicPro
         MusicProcessor: A test processor.
     """
     # Mock database manager
-    mock_db = mocker.patch("omym.features.metadata.usecases.music_file_processor.DatabaseManager").return_value
+    mock_db = mocker.patch("omym.features.metadata.usecases.processing.music_file_processor.DatabaseManager").return_value
     mock_db.conn = mocker.MagicMock()
 
     # Mock DAOs
-    mock_before_dao = mocker.patch("omym.features.metadata.usecases.music_file_processor.ProcessingBeforeDAO").return_value
-    mock_after_dao = mocker.patch("omym.features.metadata.usecases.music_file_processor.ProcessingAfterDAO").return_value
-    mock_artist_dao = mocker.patch("omym.features.metadata.usecases.music_file_processor.ArtistCacheDAO").return_value
-    mock_preview_dao = mocker.patch("omym.features.metadata.usecases.music_file_processor.ProcessingPreviewDAO").return_value
+    mock_before_dao = mocker.patch("omym.features.metadata.usecases.processing.music_file_processor.ProcessingBeforeDAO").return_value
+    mock_after_dao = mocker.patch("omym.features.metadata.usecases.processing.music_file_processor.ProcessingAfterDAO").return_value
+    mock_artist_dao = mocker.patch("omym.features.metadata.usecases.processing.music_file_processor.ArtistCacheDAO").return_value
+    mock_preview_dao = mocker.patch("omym.features.metadata.usecases.processing.music_file_processor.ProcessingPreviewDAO").return_value
 
     # Configure DAO behavior
     _ = mock_before_dao.check_file_exists.return_value = False
@@ -116,7 +116,7 @@ class TestMusicProcessor:
 
         # Mock metadata extraction
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -153,7 +153,7 @@ class TestMusicProcessor:
         _ = source_file.write_bytes(b"audio")
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -180,7 +180,7 @@ class TestMusicProcessor:
         _ = artwork_file.write_bytes(b"artwork")
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -210,7 +210,7 @@ class TestMusicProcessor:
         source_file.touch()
 
         extractor_mock = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -245,7 +245,7 @@ class TestMusicProcessor:
         original_album_artist = metadata_copy.album_artist
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata_copy,
         )
         processor.romanization.ensure_scheduled = MagicMock()
@@ -310,7 +310,7 @@ class TestMusicProcessor:
         )
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             side_effect=AssertionError("Extraction should be skipped when preview exists"),
         )
 
@@ -340,7 +340,7 @@ class TestMusicProcessor:
         _ = artwork_file.write_bytes(b"artwork")
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -394,7 +394,7 @@ class TestMusicProcessor:
         )
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=TrackMetadata(
                 title="Title",
                 artist="Artist",
@@ -430,7 +430,7 @@ class TestMusicProcessor:
         _ = lyrics_file.write_text("[00:00.00]Existing\n")
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -470,7 +470,7 @@ class TestMusicProcessor:
         source_file.touch()
 
         # Mock metadata extraction to fail
-        _ = mocker.patch("omym.features.metadata.usecases.file_runner.MetadataExtractor.extract", return_value=None)
+        _ = mocker.patch("omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract", return_value=None)
 
         # Act
         result = processor.process_file(source_file)
@@ -498,7 +498,7 @@ class TestMusicProcessor:
 
         # Mock metadata extraction
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -548,7 +548,7 @@ class TestMusicProcessor:
             (source_dir / name).touch()
 
         # Mock metadata extraction
-        _ = mocker.patch("omym.features.metadata.usecases.file_runner.MetadataExtractor.extract", return_value=metadata)
+        _ = mocker.patch("omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract", return_value=metadata)
 
         # Mock file hash calculation to return different hashes
         def mock_hash(file_path: Path) -> str:
@@ -614,7 +614,7 @@ class TestMusicProcessor:
         unsupported_file.touch()
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -648,7 +648,7 @@ class TestMusicProcessor:
         new_file.touch()
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
 
@@ -729,19 +729,19 @@ class TestMusicProcessor:
 
         remaining = {tmp_path / "unprocessed" / "leftover.txt"}
         _ = mocker.patch(
-            "omym.features.metadata.usecases.music_file_processor.snapshot_unprocessed_candidates",
+            "omym.features.metadata.usecases.processing.music_file_processor.snapshot_unprocessed_candidates",
             return_value=remaining,
         )
         _ = mocker.patch(
-            "omym.features.metadata.usecases.music_file_processor.run_directory_processing",
+            "omym.features.metadata.usecases.processing.music_file_processor.run_directory_processing",
             return_value=[],
         )
         _ = mocker.patch(
-            "omym.features.metadata.usecases.music_file_processor.calculate_pending_unprocessed",
+            "omym.features.metadata.usecases.processing.music_file_processor.calculate_pending_unprocessed",
             return_value=remaining,
         )
         relocate_mock = mocker.patch(
-            "omym.features.metadata.usecases.music_file_processor.relocate_unprocessed_files",
+            "omym.features.metadata.usecases.processing.music_file_processor.relocate_unprocessed_files",
             return_value=[],
         )
 
@@ -770,7 +770,7 @@ class TestMusicProcessor:
         (source_dir / "track.mp3").touch()
 
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=metadata,
         )
         _ = mocker.patch.object(
@@ -840,7 +840,7 @@ class TestMusicProcessor:
             return_value=target_path,
         )
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=TrackMetadata(
                 title="Title",
                 artist="Artist",
@@ -896,7 +896,7 @@ class TestMusicProcessor:
             return_value=source_file,
         )
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=TrackMetadata(
                 title="Title",
                 artist="Artist",
@@ -941,7 +941,7 @@ class TestMusicProcessor:
             return_value=organized_file,
         )
         _ = mocker.patch(
-            "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+            "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
             return_value=TrackMetadata(
                 title="Title",
                 artist="Artist",
@@ -1031,7 +1031,7 @@ class TestMusicProcessor:
             (source_dir / name).touch()
 
         # Mock metadata extraction
-        _ = mocker.patch("omym.features.metadata.usecases.file_runner.MetadataExtractor.extract", return_value=metadata)
+        _ = mocker.patch("omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract", return_value=metadata)
 
         # Act
         results = processor.process_directory(source_dir)
@@ -1074,13 +1074,13 @@ class TestMusicProcessor:
         existing_file.touch()
 
         # Mock metadata extraction
-        _ = mocker.patch("omym.features.metadata.usecases.file_runner.MetadataExtractor.extract", return_value=metadata)
+        _ = mocker.patch("omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract", return_value=metadata)
 
         # Mock file hash calculation
         _ = mocker.patch.object(processor, "_calculate_file_hash", return_value=file_hash)
 
         # Mock database check to indicate file exists
-        mock_before_dao = mocker.patch("omym.features.metadata.usecases.music_file_processor.ProcessingBeforeDAO").return_value
+        mock_before_dao = mocker.patch("omym.features.metadata.usecases.processing.music_file_processor.ProcessingBeforeDAO").return_value
         mock_before_dao.check_file_exists.return_value = True
         mock_before_dao.get_target_path.return_value = str(existing_file)
 
@@ -1120,10 +1120,10 @@ class TestMusicProcessor:
         existing_file.touch()
 
         # Mock metadata extraction
-        _ = mocker.patch("omym.features.metadata.usecases.file_runner.MetadataExtractor.extract", return_value=metadata)
+        _ = mocker.patch("omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract", return_value=metadata)
 
         # Mock database check to indicate file exists
-        mock_before_dao = mocker.patch("omym.features.metadata.usecases.music_file_processor.ProcessingBeforeDAO").return_value
+        mock_before_dao = mocker.patch("omym.features.metadata.usecases.processing.music_file_processor.ProcessingBeforeDAO").return_value
         mock_before_dao.check_file_exists.return_value = True
         mock_before_dao.get_target_path.return_value = str(existing_file)
 
@@ -1157,10 +1157,10 @@ class TestMusicProcessor:
         source_file.touch()
 
         # Mock metadata extraction
-        _ = mocker.patch("omym.features.metadata.usecases.file_runner.MetadataExtractor.extract", return_value=metadata)
+        _ = mocker.patch("omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract", return_value=metadata)
 
         # Mock shutil.move to raise an error
-        mock_move = mocker.patch("omym.features.metadata.usecases.file_operations.shutil.move")
+        mock_move = mocker.patch("omym.features.metadata.usecases.file_management.file_operations.shutil.move")
         mock_move.side_effect = OSError("Failed to move file: Test error")
 
         # Act
@@ -1255,7 +1255,7 @@ class TestMusicProcessor:
         stub_artist = StubArtistCache()
 
         configure_mock = mocker.patch(
-            "omym.features.metadata.usecases.music_file_processor.configure_romanization_cache"
+            "omym.features.metadata.usecases.processing.music_file_processor.configure_romanization_cache"
         )
 
         processor = MusicProcessor(
@@ -1302,7 +1302,7 @@ def test_dry_run_skips_persistent_state(
         file_extension=".mp3",
     )
     _ = mocker.patch(
-        "omym.features.metadata.usecases.file_runner.MetadataExtractor.extract",
+        "omym.features.metadata.usecases.processing.file_runner.MetadataExtractor.extract",
         return_value=metadata,
     )
 

--- a/tests/features/metadata/test_unprocessed_cleanup.py
+++ b/tests/features/metadata/test_unprocessed_cleanup.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 
 from omym.config.settings import UNPROCESSED_DIR_NAME
 from omym.features.metadata.usecases.ports import FilesystemPort
-from omym.features.metadata.usecases.unprocessed_cleanup import relocate_unprocessed_files
+from omym.features.metadata.usecases.cleanup.unprocessed_cleanup import relocate_unprocessed_files
 
 
 def test_relocate_unprocessed_files_invokes_filesystem_port(

--- a/tests/features/metadata/usecases/test_file_operations.py
+++ b/tests/features/metadata/usecases/test_file_operations.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from omym.features.metadata.usecases import file_operations
+from omym.features.metadata.usecases.file_management import file_operations
 
 
 def test_calculate_file_hash_matches_sha256(

--- a/tests/features/metadata/usecases/test_package_layout.py
+++ b/tests/features/metadata/usecases/test_package_layout.py
@@ -1,0 +1,53 @@
+"""
+/*
+Path: tests/features/metadata/usecases/test_package_layout.py
+Summary: Verifies reorganised metadata use case package exports.
+Why: Guard against regressions when modules move between subpackages.
+*/
+"""
+
+"""Ensure reorganised metadata use case packages remain importable."""
+
+from importlib import import_module
+
+
+def test_processing_subpackage_exposes_flow_modules() -> None:
+    """Processing package should expose orchestration helpers via __all__."""
+
+    processing = import_module("omym.features.metadata.usecases.processing")
+
+    assert hasattr(processing, "directory_runner")
+    assert hasattr(processing, "file_runner")
+    assert hasattr(processing, "music_file_processor")
+    assert hasattr(processing, "processing_types")
+
+
+def test_assets_subpackage_exposes_helpers() -> None:
+    """Assets package should re-export detection and logging helpers."""
+
+    assets = import_module("omym.features.metadata.usecases.assets")
+
+    assert hasattr(assets, "asset_detection")
+    assert hasattr(assets, "asset_logging")
+    assert hasattr(assets, "artwork_assets")
+    assert hasattr(assets, "lyrics_assets")
+    assert hasattr(assets, "associated_assets")
+
+
+def test_file_management_subpackage_exposes_utilities() -> None:
+    """File management package should surface filesystem helper modules."""
+
+    file_management = import_module("omym.features.metadata.usecases.file_management")
+
+    assert hasattr(file_management, "file_context")
+    assert hasattr(file_management, "file_duplicate")
+    assert hasattr(file_management, "file_operations")
+    assert hasattr(file_management, "file_success")
+
+
+def test_cleanup_subpackage_exposes_cleanup_helpers() -> None:
+    """Cleanup package should expose lifecycle utilities."""
+
+    cleanup = import_module("omym.features.metadata.usecases.cleanup")
+
+    assert hasattr(cleanup, "unprocessed_cleanup")


### PR DESCRIPTION
## Summary
- group metadata use case helpers into processing, assets, file_management, and cleanup subpackages with lazy exports
- update metadata API, CLI wiring, and tests to reference the new package layout and document the structure in the repo map
- add a regression test that verifies the reorganised packages remain importable

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68e04621e04c832a84b73429beb7b8e3