### PR TITLE
Inject filesystem port into metadata asset helpers

### DIFF
--- a/src/omym/features/metadata/usecases/assets/artwork_assets.py
+++ b/src/omym/features/metadata/usecases/assets/artwork_assets.py
@@ -1,7 +1,6 @@
-"""src/omym/features/metadata/usecases/assets/artwork_assets.py
-Where: Metadata feature usecases layer.
-What: Handle movement and summarisation of artwork files for tracks.
-Why: Separate artwork-specific behaviour from the core processor.
+"""
+Summary: Move and summarise artwork files during metadata processing.
+Why: Keep artwork-specific filesystem behaviour isolated behind ports.
 """
 
 from __future__ import annotations
@@ -11,10 +10,9 @@ import shutil
 from pathlib import Path
 from collections.abc import Iterable
 
-from omym.platform.filesystem import ensure_parent_directory
-
 from .asset_logging import ProcessLogger
 from ..processing.processing_types import ArtworkProcessingResult, ProcessingEvent
+from ..ports import FilesystemPort
 
 
 def process_artwork(
@@ -28,6 +26,7 @@ def process_artwork(
     total: int | None,
     source_root: Path,
     target_root: Path,
+    filesystem: FilesystemPort,
 ) -> list[ArtworkProcessingResult]:
     """Move artwork files so they follow the resolved track target."""
 
@@ -184,7 +183,7 @@ def process_artwork(
             continue
 
         try:
-            _ = ensure_parent_directory(target_artwork_path)
+            _ = filesystem.ensure_parent_directory(target_artwork_path)
             _ = shutil.move(str(artwork_path), str(target_artwork_path))
         except Exception as exc:
             error_message = str(exc) if str(exc) else type(exc).__name__

--- a/src/omym/features/metadata/usecases/assets/lyrics_assets.py
+++ b/src/omym/features/metadata/usecases/assets/lyrics_assets.py
@@ -1,7 +1,6 @@
-"""src/omym/features/metadata/usecases/assets/lyrics_assets.py
-Where: Metadata feature usecases layer.
-What: Handle movement and summarisation of lyrics files tied to tracks.
-Why: Keep lyrics-specific side effects isolated from core processing logic.
+"""
+Summary: Move and summarise lyrics files alongside processed tracks.
+Why: Ensure lyrics logic stays pure by relying on filesystem ports.
 """
 
 from __future__ import annotations
@@ -10,10 +9,9 @@ import logging
 import shutil
 from pathlib import Path
 
-from omym.platform.filesystem import ensure_parent_directory
-
 from .asset_logging import ProcessLogger
 from ..processing.processing_types import LyricsProcessingResult, ProcessingEvent
+from ..ports import FilesystemPort
 
 
 def process_lyrics(
@@ -27,6 +25,7 @@ def process_lyrics(
     total: int | None,
     source_root: Path,
     target_root: Path,
+    filesystem: FilesystemPort,
 ) -> LyricsProcessingResult:
     """Move a lyrics file so that it matches the target music file path."""
 
@@ -132,7 +131,7 @@ def process_lyrics(
         )
 
     try:
-        _ = ensure_parent_directory(target_lyrics_path)
+        _ = filesystem.ensure_parent_directory(target_lyrics_path)
         _ = shutil.move(str(lyrics_path), str(target_lyrics_path))
     except Exception as exc:  # pragma: no cover - defensive logging
         error_message = str(exc) if str(exc) else type(exc).__name__

--- a/src/omym/features/metadata/usecases/processing/file_context.py
+++ b/src/omym/features/metadata/usecases/processing/file_context.py
@@ -1,6 +1,6 @@
-"""src/omym/features/metadata/usecases/processing/file_context.py
-What: Shared state container for per-file processing helpers.
-Why: Avoid long parameter lists when coordinating helper functions.
+"""
+Summary: Share per-file processor state across helper functions.
+Why: Reduce parameter churn while keeping dependencies explicit.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from .processing_types import (
     LyricsProcessingResult,
     ProcessingEvent,
 )
+from ..ports import FilesystemPort
 
 
 class ProcessorHooks(Protocol):
@@ -24,6 +25,7 @@ class ProcessorHooks(Protocol):
 
     dry_run: bool
     artist_id_generator: "CachedArtistIdGenerator"
+    filesystem: FilesystemPort
 
     def log_processing(
         self,
@@ -51,6 +53,12 @@ class FileProcessingContext:
     warnings: list[str] = field(default_factory=list)
     lyrics_result: LyricsProcessingResult | None = None
     artwork_results: list[ArtworkProcessingResult] = field(default_factory=list)
+
+    @property
+    def filesystem(self) -> FilesystemPort:
+        """Expose the filesystem port used by the active processor."""
+
+        return self.processor.filesystem
 
 
 __all__ = ["FileProcessingContext", "ProcessorHooks"]

--- a/src/omym/features/metadata/usecases/processing/file_duplicate.py
+++ b/src/omym/features/metadata/usecases/processing/file_duplicate.py
@@ -1,5 +1,5 @@
-"""src/omym/features/metadata/usecases/processing/file_duplicate.py
-What: Handle duplicate detection branch for file processing.
+"""
+Summary: Handle duplicate detection branch for file processing.
 Why: Keep the main runner concise by isolating duplicate logic.
 """
 
@@ -48,6 +48,7 @@ def handle_duplicate(
                 total=ctx.total,
                 source_root=ctx.source_root,
                 target_root=ctx.target_root,
+                filesystem=ctx.filesystem,
             )
             ctx.warnings.extend(summarize_lyrics(ctx.lyrics_result))
         if associated_artwork:
@@ -61,6 +62,7 @@ def handle_duplicate(
                 total=ctx.total,
                 source_root=ctx.source_root,
                 target_root=ctx.target_root,
+                filesystem=ctx.filesystem,
             )
             ctx.artwork_results.extend(artwork_plan)
             ctx.warnings.extend(summarize_artwork(artwork_plan))
@@ -75,6 +77,7 @@ def handle_duplicate(
             total=ctx.total,
             source_root=ctx.source_root,
             target_root=ctx.target_root,
+            filesystem=ctx.filesystem,
         )
         ctx.artwork_results.extend(artwork_plan)
         ctx.warnings.extend(summarize_artwork(artwork_plan))

--- a/src/omym/features/metadata/usecases/processing/file_runner.py
+++ b/src/omym/features/metadata/usecases/processing/file_runner.py
@@ -22,6 +22,7 @@ from omym.features.path.usecases.renamer import (
 from ..assets import find_associated_lyrics, resolve_directory_artwork
 from ..ports import (
     ArtistCachePort,
+    FilesystemPort,
     PreviewCachePort,
     ProcessingAfterPort,
     ProcessingBeforePort,
@@ -61,6 +62,7 @@ class ProcessorLike(Protocol):
     file_name_generator: FileNameGenerator
     SUPPORTED_EXTENSIONS: set[str]
     SUPPORTED_IMAGE_EXTENSIONS: set[str]
+    filesystem: FilesystemPort
 
     def _calculate_file_hash(self, file_path: Path) -> str: ...
 

--- a/src/omym/features/metadata/usecases/processing/file_success.py
+++ b/src/omym/features/metadata/usecases/processing/file_success.py
@@ -1,6 +1,6 @@
-"""src/omym/features/metadata/usecases/processing/file_success.py
-What: Finalise successful processing of a track file.
-Why: Keep the main runner lean by extracting post-move handling.
+"""
+Summary: Finalise successful processing of an organised track file.
+Why: Separate post-move handling from the main processing runner.
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ def complete_success(
             total=ctx.total,
             source_root=ctx.source_root,
             target_root=ctx.target_root,
+            filesystem=ctx.filesystem,
         )
         ctx.warnings.extend(summarize_lyrics(ctx.lyrics_result))
 
@@ -50,6 +51,7 @@ def complete_success(
             total=ctx.total,
             source_root=ctx.source_root,
             target_root=ctx.target_root,
+            filesystem=ctx.filesystem,
         )
         ctx.artwork_results.extend(artwork_plan)
         ctx.warnings.extend(summarize_artwork(artwork_plan))

--- a/tests/features/metadata/test_artwork_assets.py
+++ b/tests/features/metadata/test_artwork_assets.py
@@ -1,0 +1,83 @@
+"""
+Summary: Verify artwork asset helpers integrate with filesystem ports.
+Why: Ensure artwork moves rely on injected filesystem behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omym.features.metadata.usecases.assets import (
+    ProcessLogger,
+    process_artwork,
+    summarize_artwork,
+)
+from omym.features.metadata.usecases.processing import (
+    ArtworkProcessingResult,
+    ProcessingEvent,
+)
+
+
+class StubFilesystem:
+    """Track filesystem interactions for assertions."""
+
+    def __init__(self) -> None:
+        self.ensure_calls: list[Path] = []
+
+    def ensure_parent_directory(self, path: Path) -> Path:
+        self.ensure_calls.append(path)
+        _ = path.parent.mkdir(parents=True, exist_ok=True)
+        return path.parent
+
+    def remove_empty_directories(self, directory: Path) -> None:  # pragma: no cover - unused
+        del directory
+
+
+class DummyLogger(ProcessLogger):
+    """Capture structured log calls for assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, ProcessingEvent, str]] = []
+
+    def __call__(
+        self,
+        level: int,
+        event: ProcessingEvent,
+        message: str,
+        *message_args: object,
+        **context: object,
+    ) -> None:
+        del message_args, context
+        self.calls.append((level, event, message))
+
+
+def test_process_artwork_moves_file_using_port(tmp_path: Path) -> None:
+    """Artwork moves should ensure the destination directory through the port."""
+
+    logger = DummyLogger()
+    filesystem = StubFilesystem()
+
+    track_target = tmp_path / "Library" / "Artist" / "Album" / "track.mp3"
+    artwork_source = tmp_path / "cover.jpg"
+    _ = artwork_source.write_bytes(b"artwork")
+
+    results = process_artwork(
+        [artwork_source],
+        track_target,
+        dry_run=False,
+        log=logger,
+        process_id="pid",
+        sequence=1,
+        total=1,
+        source_root=tmp_path,
+        target_root=tmp_path / "Library",
+        filesystem=filesystem,
+    )
+
+    assert results
+    result = results[0]
+    assert isinstance(result, ArtworkProcessingResult)
+    assert result.moved is True
+    assert result.target_path.parent == track_target.parent
+    assert filesystem.ensure_calls == [track_target.with_name(artwork_source.name)]
+    assert summarize_artwork(results) == []

--- a/tests/features/metadata/test_file_duplicate.py
+++ b/tests/features/metadata/test_file_duplicate.py
@@ -1,0 +1,152 @@
+"""Tests for duplicate handling path in file processing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omym.features.metadata.usecases.processing import (
+    ArtworkProcessingResult,
+    LyricsProcessingResult,
+    ProcessingEvent,
+)
+from omym.features.metadata.usecases.processing.file_context import FileProcessingContext
+from omym.features.metadata.usecases.processing.file_duplicate import handle_duplicate
+from omym.features.metadata.usecases.ports import ArtistCachePort, FilesystemPort
+from omym.features.path.usecases.renamer import CachedArtistIdGenerator
+
+
+class StubFilesystem(FilesystemPort):
+    """Record filesystem interactions issued by duplicate handlers."""
+
+    def __init__(self) -> None:
+        self.ensure_calls: list[Path] = []
+
+    def ensure_parent_directory(self, path: Path) -> Path:
+        self.ensure_calls.append(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path.parent
+
+    def remove_empty_directories(self, directory: Path) -> None:  # pragma: no cover - unused
+        del directory
+
+
+class StubArtistCache(ArtistCachePort):
+    """Store artist identifiers and romanized names in-memory for tests."""
+
+    def __init__(self) -> None:
+        self.ids: dict[str, str] = {}
+        self.romanized: dict[str, tuple[str, str | None]] = {}
+
+    def insert_artist_id(self, artist_name: str, artist_id: str) -> bool:
+        self.ids[artist_name] = artist_id
+        return True
+
+    def get_artist_id(self, artist_name: str) -> str | None:
+        return self.ids.get(artist_name)
+
+    def get_romanized_name(self, artist_name: str) -> str | None:
+        stored = self.romanized.get(artist_name)
+        return stored[0] if stored else None
+
+    def upsert_romanized_name(
+        self,
+        artist_name: str,
+        romanized_name: str,
+        source: str | None = None,
+    ) -> bool:
+        self.romanized[artist_name] = (romanized_name, source)
+        return True
+
+    def clear_cache(self) -> bool:
+        self.ids.clear()
+        self.romanized.clear()
+        return True
+
+
+class StubProcessor:
+    """Minimal processor satisfying the hooks expected by helpers."""
+
+    dry_run: bool
+    filesystem: FilesystemPort
+    artist_id_generator: CachedArtistIdGenerator
+    log_calls: list[tuple[int, ProcessingEvent, str]]
+
+    def __init__(self, filesystem: FilesystemPort) -> None:
+        self.dry_run = False
+        self.filesystem = filesystem
+        self.artist_id_generator = CachedArtistIdGenerator(StubArtistCache())
+        self.log_calls = []
+
+    def log_processing(
+        self,
+        level: int,
+        event: ProcessingEvent,
+        message: str,
+        *args: object,
+        **context: object,
+    ) -> None:
+        del args, context
+        self.log_calls.append((level, event, message))
+
+
+def _build_context(
+    tmp_path: Path,
+) -> tuple[FileProcessingContext, StubProcessor, Path, StubFilesystem]:
+    filesystem = StubFilesystem()
+    processor = StubProcessor(filesystem)
+    track_path = tmp_path / "Library" / "Artist" / "Album" / "track.mp3"
+    track_path.parent.mkdir(parents=True, exist_ok=True)
+    _ = track_path.write_bytes(b"music")
+
+    ctx = FileProcessingContext(
+        processor=processor,
+        file_path=track_path,
+        process_id="pid",
+        sequence=1,
+        total=1,
+        source_root=tmp_path,
+        target_root=tmp_path / "Library",
+    )
+    return ctx, processor, track_path, filesystem
+
+
+def test_handle_duplicate_moves_assets_via_port(tmp_path: Path) -> None:
+    """Duplicate handling should reuse the filesystem port for asset moves."""
+
+    ctx, _processor, track_path, filesystem = _build_context(tmp_path)
+
+    lyrics_source = tmp_path / "lyrics.lrc"
+    artwork_source = tmp_path / "cover.jpg"
+    _ = lyrics_source.write_text("[00:00.00]Test\n")
+    _ = artwork_source.write_bytes(b"artwork")
+
+    result = handle_duplicate(
+        ctx,
+        target_raw=track_path,
+        associated_lyrics=lyrics_source,
+        associated_artwork=[artwork_source],
+    )
+
+    assert result.success is True
+    assert result.skipped_duplicate is False
+
+    assert isinstance(result.lyrics_result, LyricsProcessingResult)
+    assert result.lyrics_result.moved is True
+
+    assert result.artwork_results
+    artwork_result = result.artwork_results[0]
+    assert isinstance(artwork_result, ArtworkProcessingResult)
+    assert artwork_result.moved is True
+
+    expected_target_lyrics = track_path.with_suffix(".lrc")
+    expected_target_artwork = track_path.with_name(artwork_source.name)
+
+    assert filesystem.ensure_calls == [
+        expected_target_lyrics,
+        expected_target_artwork,
+    ]
+    assert expected_target_lyrics.exists()
+    assert expected_target_artwork.exists()
+    assert not lyrics_source.exists()
+    assert not artwork_source.exists()
+

--- a/tests/features/metadata/test_file_runner_reorganize.py
+++ b/tests/features/metadata/test_file_runner_reorganize.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 
 from omym.features.metadata.usecases.ports import (
     ArtistCachePort,
+    FilesystemPort,
     ProcessingAfterPort,
     ProcessingBeforePort,
     PreviewCachePort,
@@ -95,6 +96,17 @@ class _StubPreviewDAO(PreviewCachePort):
     def delete_preview(self, file_hash: str) -> bool:
         del file_hash
         return True
+
+
+class _StubFilesystem(FilesystemPort):
+    """Filesystem port stub ensuring target directories exist."""
+
+    def ensure_parent_directory(self, path: Path) -> Path:
+        _ = path.parent.mkdir(parents=True, exist_ok=True)
+        return path.parent
+
+    def remove_empty_directories(self, directory: Path) -> None:  # pragma: no cover - unused
+        del directory
 
 
 class _StubArtistDAO(ArtistCachePort):
@@ -182,6 +194,7 @@ class _StubProcessor:
         self._romanization = _StubRomanization()
         self._new_target = new_target
         self.move_calls = []
+        self.filesystem: FilesystemPort = _StubFilesystem()
 
     def _calculate_file_hash(self, file_path: Path) -> str:
         del file_path


### PR DESCRIPTION
## Summary
- inject the filesystem port into `process_artwork` and `process_lyrics` so use cases no longer import the platform helper directly
- expose the filesystem port through `ProcessorHooks`/`FileProcessingContext` and plumb it through duplicate/success handlers
- add focused tests covering the new port usage for lyrics and artwork helpers alongside updated processor stubs

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68e0d1415bc4832a97c0bb52b69b7e68