### PR TITLE
Refactor metadata romanization wiring

### DIFF
--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -9,6 +9,7 @@ review_cadence: quarterly
     - `domain/`: pure business rules for the feature.
     - `usecases/`: application services, commands, queries, and port protocols.
     - `adapters/`: infrastructure implementations (DB, filesystem, external APIs) that fulfil ports.
+      - `metadata/adapters/`: `LocalFilesystemAdapter` (filesystem helpers) and `MusicBrainzRomanizationAdapter` (MusicBrainz romanization port).
   - [`omym/platform/`](../src/omym/platform): Cross-cutting technical services—database manager, filesystem primitives, logging bootstrap, configuration providers, MusicBrainz HTTP client.
     - `musicbrainz/`: split into focused modules (`http_client`, `rate_limit`, `romanization`, `cache`, `user_agent`) with `client.py` acting as the public façade.
   - [`omym/shared/`](../src/omym/shared): Feature-agnostic value objects, typed results, error types, functional helpers.

--- a/src/omym/features/metadata/adapters/__init__.py
+++ b/src/omym/features/metadata/adapters/__init__.py
@@ -1,7 +1,7 @@
-"""src/omym/features/metadata/adapters/__init__.py
-What: Package marker for metadata adapters.
-Why: Allow adapter modules to live alongside use cases with a clear namespace."""
+"""Summary: Package marker for metadata adapters.
+Why: Keep adapter exports together for easy discovery."""
 
 from .filesystem_adapter import LocalFilesystemAdapter
+from .romanization_adapter import MusicBrainzRomanizationAdapter
 
-__all__ = ["LocalFilesystemAdapter"]
+__all__ = ["LocalFilesystemAdapter", "MusicBrainzRomanizationAdapter"]

--- a/src/omym/features/metadata/adapters/romanization_adapter.py
+++ b/src/omym/features/metadata/adapters/romanization_adapter.py
@@ -1,0 +1,33 @@
+"""Summary: MusicBrainz romanization adapter bridging the platform client.
+Why: Provide a port implementation that wires cache configuration and fetch helpers."""
+
+from __future__ import annotations
+
+from omym.features.metadata.usecases.ports import ArtistCachePort, RomanizationPort
+from omym.platform.musicbrainz.client import (
+    configure_romanization_cache,
+    fetch_romanized_name,
+)
+from omym.platform.musicbrainz.cache import save_cached_name
+
+
+class MusicBrainzRomanizationAdapter(RomanizationPort):
+    """Delegate romanization operations to the MusicBrainz platform helpers."""
+
+    def configure_cache(self, cache: ArtistCachePort | None) -> None:
+        configure_romanization_cache(cache)
+
+    def fetch_romanized_name(self, artist_name: str) -> str | None:
+        return fetch_romanized_name(artist_name)
+
+    def save_cached_name(
+        self,
+        original: str,
+        romanized: str,
+        *,
+        source: str | None = None,
+    ) -> None:
+        save_cached_name(original, romanized, source=source)
+
+
+__all__ = ["MusicBrainzRomanizationAdapter"]

--- a/src/omym/features/metadata/usecases/ports.py
+++ b/src/omym/features/metadata/usecases/ports.py
@@ -1,9 +1,5 @@
-"""Ports defining metadata use case dependencies.
-
-Where: features/metadata/usecases.
-What: Protocols capturing the interactions MusicProcessor needs.
-Why: Decouple use cases from concrete DB and cache adapters for testing and swaps.
-"""
+"""Summary: Ports defining metadata use case dependencies.
+Why: Decouple use cases from concrete adapters so tests and swaps stay simple."""
 
 from __future__ import annotations
 
@@ -82,6 +78,29 @@ class ArtistCachePort(Protocol):
 
     def clear_cache(self) -> bool:
         """Erase cached artist data."""
+        ...
+
+
+@runtime_checkable
+class RomanizationPort(Protocol):
+    """Port abstracting MusicBrainz romanization helpers."""
+
+    def configure_cache(self, cache: ArtistCachePort | None) -> None:
+        """Attach the persistence layer used by remote fetch helpers."""
+        ...
+
+    def fetch_romanized_name(self, artist_name: str) -> str | None:
+        """Retrieve a romanized name for ``artist_name`` when available."""
+        ...
+
+    def save_cached_name(
+        self,
+        original: str,
+        romanized: str,
+        *,
+        source: str | None = None,
+    ) -> None:
+        """Persist a romanized mapping so future runs reuse the value."""
         ...
 
 

--- a/tests/features/metadata/adapters/test_romanization_adapter.py
+++ b/tests/features/metadata/adapters/test_romanization_adapter.py
@@ -1,0 +1,44 @@
+"""Summary: Tests for the MusicBrainz romanization adapter.
+Why: Verify delegation to platform-level MusicBrainz helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pytest_mock import MockerFixture
+
+from omym.features.metadata.adapters import MusicBrainzRomanizationAdapter
+
+
+def test_configure_cache_delegates_to_platform(mocker: MockerFixture) -> None:
+    """Ensure cache configuration forwards to the platform helper."""
+
+    adapter = MusicBrainzRomanizationAdapter()
+    cache = MagicMock()
+    configure = mocker.patch(
+        "omym.features.metadata.adapters.romanization_adapter.configure_romanization_cache"
+    )
+
+    adapter.configure_cache(cache)
+
+    configure.assert_called_once_with(cache)
+
+
+def test_fetch_and_save_delegate_to_platform(mocker: MockerFixture) -> None:
+    """Fetch and cache calls must reuse the platform wiring."""
+
+    adapter = MusicBrainzRomanizationAdapter()
+    fetch = mocker.patch(
+        "omym.features.metadata.adapters.romanization_adapter.fetch_romanized_name",
+        return_value="Utada Hikaru",
+    )
+    saver = mocker.patch(
+        "omym.features.metadata.adapters.romanization_adapter.save_cached_name"
+    )
+
+    result = adapter.fetch_romanized_name("宇多田ヒカル")
+    adapter.save_cached_name("宇多田ヒカル", "Utada Hikaru", source="musicbrainz")
+
+    assert result == "Utada Hikaru"
+    fetch.assert_called_once_with("宇多田ヒカル")
+    saver.assert_called_once_with("宇多田ヒカル", "Utada Hikaru", source="musicbrainz")


### PR DESCRIPTION
## Summary
- introduce a RomanizationPort protocol and MusicBrainzRomanizationAdapter for metadata use cases
- inject the new port into ArtistRomanizer, RomanizationCoordinator, MusicProcessor, and the organizing service
- update documentation and tests to cover the new adapter and dependency wiring

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68e0e1118c50832abaf8789d77a26793