### PR TITLE
Add renamer ports and adapter for metadata processing

### DIFF
--- a/src/omym/features/metadata/adapters/__init__.py
+++ b/src/omym/features/metadata/adapters/__init__.py
@@ -5,10 +5,13 @@ Why: Keep adapter exports together for easy discovery.
 
 from .artist_cache_adapter import DryRunArtistCacheAdapter
 from .filesystem_adapter import LocalFilesystemAdapter
+from .path_renamer_adapter import PathRenamerAdapter, build_path_renamer_ports
 from .romanization_adapter import MusicBrainzRomanizationAdapter
 
 __all__ = [
     "DryRunArtistCacheAdapter",
     "LocalFilesystemAdapter",
+    "PathRenamerAdapter",
     "MusicBrainzRomanizationAdapter",
+    "build_path_renamer_ports",
 ]

--- a/src/omym/features/metadata/adapters/path_renamer_adapter.py
+++ b/src/omym/features/metadata/adapters/path_renamer_adapter.py
@@ -1,0 +1,92 @@
+"""Summary: Adapter wiring metadata renamer ports to the path feature helpers.
+Why: Keep metadata use cases decoupled from path renamer implementations via explicit ports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import final
+
+from omym.features.metadata.usecases.ports import (
+    ArtistCachePort,
+    ArtistIdGeneratorPort,
+    DirectoryNamingPort,
+    FileNameGenerationPort,
+    RenamerPorts,
+)
+from omym.features.path.usecases.renamer import (
+    CachedArtistIdGenerator,
+    DirectoryGenerator,
+    FileNameGenerator,
+)
+from omym.shared.track_metadata import TrackMetadata
+
+
+@final
+class _ArtistIdGeneratorAdapter(ArtistIdGeneratorPort):
+    """Wrap the path cached artist ID generator behind the metadata port."""
+
+    def __init__(self, delegate: CachedArtistIdGenerator) -> None:
+        self._delegate = delegate
+
+    def generate(self, artist_name: str | None) -> str:
+        return self._delegate.generate(artist_name)
+
+
+@final
+class _DirectoryGeneratorAdapter(DirectoryNamingPort):
+    """Adapt ``DirectoryGenerator`` to the metadata directory port."""
+
+    def __init__(self, delegate: DirectoryGenerator) -> None:
+        self._delegate = delegate
+
+    def register_album_year(self, metadata: TrackMetadata) -> None:
+        self._delegate.register_album_year(metadata)
+
+    def generate(self, metadata: TrackMetadata) -> Path:
+        return self._delegate.generate(metadata)
+
+
+@final
+class _FileNameGeneratorAdapter(FileNameGenerationPort):
+    """Adapt ``FileNameGenerator`` to the metadata file-name port."""
+
+    def __init__(self, delegate: FileNameGenerator) -> None:
+        self._delegate = delegate
+
+    def register_album_track_width(self, metadata: TrackMetadata) -> None:
+        FileNameGenerator.register_album_track_width(metadata)
+
+    def generate(self, metadata: TrackMetadata) -> str:
+        return self._delegate.generate(metadata)
+
+
+@final
+class PathRenamerAdapter:
+    """Build renamer port bundles backed by the path feature renamer helpers."""
+
+    def __init__(self, artist_cache: ArtistCachePort) -> None:
+        artist_delegate = CachedArtistIdGenerator(artist_cache)
+        directory_delegate = DirectoryGenerator()
+        file_delegate = FileNameGenerator(artist_delegate)
+
+        self.artist_id: ArtistIdGeneratorPort = _ArtistIdGeneratorAdapter(artist_delegate)
+        self.directory: DirectoryNamingPort = _DirectoryGeneratorAdapter(directory_delegate)
+        self.file_name: FileNameGenerationPort = _FileNameGeneratorAdapter(file_delegate)
+
+    def as_ports(self) -> RenamerPorts:
+        """Return the component ports packaged for use-case wiring."""
+
+        return RenamerPorts(
+            directory=self.directory,
+            file_name=self.file_name,
+            artist_id=self.artist_id,
+        )
+
+
+def build_path_renamer_ports(artist_cache: ArtistCachePort) -> RenamerPorts:
+    """Create a ``RenamerPorts`` bundle backed by the path renamer helpers."""
+
+    return PathRenamerAdapter(artist_cache).as_ports()
+
+
+__all__ = ["PathRenamerAdapter", "build_path_renamer_ports"]

--- a/src/omym/features/metadata/usecases/processing/directory_runner.py
+++ b/src/omym/features/metadata/usecases/processing/directory_runner.py
@@ -1,7 +1,5 @@
-"""src/omym/features/metadata/usecases/processing/directory_runner.py
-What: Shared implementation for directory-wide music processing.
-Why: Keep MusicProcessor slim while reusing robust directory orchestration logic.
-"""
+"""Summary: Shared implementation for directory-wide music processing.
+Why: Keep MusicProcessor slim while reusing robust directory orchestration logic."""
 
 from __future__ import annotations
 
@@ -12,11 +10,14 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Protocol
 
-from omym.features.path.usecases.renamer import DirectoryGenerator, FileNameGenerator
-
 from ..extraction.romanization import RomanizationCoordinator
 from ..extraction.track_metadata_extractor import MetadataExtractor
-from ..ports import DatabaseManagerPort, FilesystemPort
+from ..ports import (
+    DatabaseManagerPort,
+    DirectoryNamingPort,
+    FileNameGenerationPort,
+    FilesystemPort,
+)
 from .processing_types import (
     DirectoryRollbackError,
     ProcessResult,
@@ -32,7 +33,8 @@ class ProcessorLike(Protocol):
     base_path: Path
     dry_run: bool
     db_manager: DatabaseManagerPort
-    directory_generator: DirectoryGenerator
+    directory_generator: DirectoryNamingPort
+    file_name_generator: FileNameGenerationPort
     filesystem: FilesystemPort
     SUPPORTED_EXTENSIONS: set[str]
 
@@ -123,7 +125,7 @@ def run_directory_processing(
         if metadata.album_artist:
             processor.romanization.ensure_scheduled(metadata.album_artist)
         processor.directory_generator.register_album_year(metadata)
-        FileNameGenerator.register_album_track_width(metadata)
+        processor.file_name_generator.register_album_track_width(metadata)
         precomputed_metadata[pre_file] = metadata
 
     processed_count = 0

--- a/src/omym/features/metadata/usecases/processing/file_context.py
+++ b/src/omym/features/metadata/usecases/processing/file_context.py
@@ -7,24 +7,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from omym.features.path.usecases.renamer import CachedArtistIdGenerator
+from typing import Protocol
 
 from .processing_types import (
     ArtworkProcessingResult,
     LyricsProcessingResult,
     ProcessingEvent,
 )
-from ..ports import FilesystemPort
+from ..ports import ArtistIdGeneratorPort, FilesystemPort
 
 
 class ProcessorHooks(Protocol):
     """Minimal interface a processor must expose to helpers."""
 
     dry_run: bool
-    artist_id_generator: "CachedArtistIdGenerator"
+    artist_id_generator: ArtistIdGeneratorPort
     filesystem: FilesystemPort
 
     def log_processing(

--- a/src/omym/features/metadata/usecases/processing/file_runner.py
+++ b/src/omym/features/metadata/usecases/processing/file_runner.py
@@ -1,8 +1,5 @@
-# /*
-# Where: features/metadata/usecases/processing/file_runner.py
-# What: Shared implementation for per-file music processing orchestration.
-# Why: Keep MusicProcessor lean by isolating procedural flow and duplicate handling.
-# */
+"""Summary: Shared implementation for per-file music processing orchestration.
+Why: Keep MusicProcessor lean by isolating procedural flow and duplicate handling."""
 
 from __future__ import annotations
 
@@ -13,16 +10,13 @@ from pathlib import Path
 from dataclasses import asdict, replace
 from typing import Any, Protocol, cast
 
-from omym.features.path.usecases.renamer import (
-    CachedArtistIdGenerator,
-    DirectoryGenerator,
-    FileNameGenerator,
-)
-
 from ..assets import find_associated_lyrics, resolve_directory_artwork
 from ..ports import (
+    ArtistIdGeneratorPort,
     ArtistCachePort,
+    DirectoryNamingPort,
     FilesystemPort,
+    FileNameGenerationPort,
     PreviewCachePort,
     ProcessingAfterPort,
     ProcessingBeforePort,
@@ -57,9 +51,9 @@ class ProcessorLike(Protocol):
     after_dao: ProcessingAfterPort
     artist_dao: ArtistCachePort
     preview_dao: PreviewCachePort
-    artist_id_generator: CachedArtistIdGenerator
-    directory_generator: DirectoryGenerator
-    file_name_generator: FileNameGenerator
+    artist_id_generator: ArtistIdGeneratorPort
+    directory_generator: DirectoryNamingPort
+    file_name_generator: FileNameGenerationPort
     SUPPORTED_EXTENSIONS: set[str]
     SUPPORTED_IMAGE_EXTENSIONS: set[str]
     filesystem: FilesystemPort

--- a/tests/application/test_organize_service.py
+++ b/tests/application/test_organize_service.py
@@ -1,8 +1,5 @@
-"""Tests for application service that orchestrates organizing.
-
-These tests verify that the service constructs a MusicProcessor and delegates
-calls appropriately. Infra details are mocked so tests remain fast and stable.
-"""
+"""Summary: Validate OrganizeMusicService builds processors and delegates requests.
+Why: Ensure application wiring remains stable while infrastructure is mocked."""
 
 import logging
 import sqlite3
@@ -18,7 +15,11 @@ from omym.application.services.organize_service import (
 )
 from omym.features.metadata import ProcessResult
 from omym.features.metadata.adapters import LocalFilesystemAdapter
-from omym.features.metadata.usecases.ports import ArtistCachePort, RomanizationPort
+from omym.features.metadata.usecases.ports import (
+    ArtistCachePort,
+    RenamerPorts,
+    RomanizationPort,
+)
 
 
 def test_build_processor_constructs_music_processor(mocker: MockerFixture) -> None:
@@ -132,7 +133,9 @@ def test_build_processor_warns_and_continues_on_cache_clear_failure(
     def processor_factory(*_: object, **kwargs: object) -> object:
         romanization_port = cast(RomanizationPort, kwargs["romanization_port"])
         artist_cache = cast(ArtistCachePort, kwargs["artist_cache"])
+        renamer_ports = cast(RenamerPorts, kwargs["renamer_ports"])
         romanization_port.configure_cache(artist_cache)
+        assert renamer_ports.artist_id is not None
         return processor_mock
 
     _ = mocker.patch(

--- a/tests/application/test_organize_service_clear.py
+++ b/tests/application/test_organize_service_clear.py
@@ -1,7 +1,5 @@
-"""Tests for maintenance flags in OrganizeMusicService.
-
-Focus on verifying delegation to DAOs rather than DB effects.
-"""
+"""Summary: Ensure OrganizeMusicService maintenance flags trigger DAO calls.
+Why: Guard against regressions where cache-clearing flags skip persistence layers."""
 
 from pathlib import Path
 from typing import cast
@@ -11,7 +9,11 @@ from omym.application.services.organize_service import (
     OrganizeMusicService,
     OrganizeRequest,
 )
-from omym.features.metadata.usecases.ports import ArtistCachePort, RomanizationPort
+from omym.features.metadata.usecases.ports import (
+    ArtistCachePort,
+    RenamerPorts,
+    RomanizationPort,
+)
 
 
 def test_clear_cache_uses_maintenance_dao(mocker: MockerFixture) -> None:
@@ -52,6 +54,8 @@ def test_clear_cache_uses_maintenance_dao(mocker: MockerFixture) -> None:
         romanization_port_kw = cast(RomanizationPort, kwargs["romanization_port"])
         romanization_port_kw.configure_cache(artist_cache_kw)
         proc_instance.romanization_port = romanization_port_kw
+        renamer_ports_kw = cast(RenamerPorts, kwargs["renamer_ports"])
+        assert renamer_ports_kw.file_name is not None
         return proc_instance
 
     mocked_proc = mocker.patch(
@@ -119,6 +123,8 @@ def test_clear_artist_cache_uses_artist_dao(mocker: MockerFixture) -> None:
         romanization_port_kw = cast(RomanizationPort, kwargs["romanization_port"])
         romanization_port_kw.configure_cache(artist_cache_kw)
         proc_instance.romanization_port = romanization_port_kw
+        renamer_ports_kw = cast(RenamerPorts, kwargs["renamer_ports"])
+        assert renamer_ports_kw.directory is not None
         return proc_instance
 
     _ = mocker.patch(

--- a/tests/architecture/test_metadata_usecase_boundaries.py
+++ b/tests/architecture/test_metadata_usecase_boundaries.py
@@ -22,3 +22,19 @@ def test_metadata_usecases_do_not_import_platform_db() -> None:
         "Use case modules must not import platform database packages; found in: "
         f"{', '.join(str(path.relative_to(repo_root)) for path in offending_files)}"
     )
+
+
+def test_metadata_usecases_do_not_import_path_feature() -> None:
+    """Ensure metadata use cases remain decoupled from the path feature renamer helpers."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    usecases_dir = repo_root / "src" / "omym" / "features" / "metadata" / "usecases"
+    offending_files: list[Path] = []
+    for path in usecases_dir.rglob("*.py"):
+        contents = path.read_text(encoding="utf-8")
+        if "omym.features.path" in contents:
+            offending_files.append(path)
+    assert offending_files == [], (
+        "Metadata use cases must depend on renamer ports via adapters; found path imports in: "
+        f"{', '.join(str(path.relative_to(repo_root)) for path in offending_files)}"
+    )

--- a/tests/features/metadata/test_music_file_processor.py
+++ b/tests/features/metadata/test_music_file_processor.py
@@ -1,5 +1,3 @@
-"""Tests for music file processing functionality."""
-
 """Summary: Validate MusicProcessor orchestration across processing scenarios.
 Why: Ensure dependency injection continues to honour processing contracts."""
 
@@ -24,6 +22,7 @@ from omym.features.metadata import (
 from omym.features.metadata.adapters import (
     DryRunArtistCacheAdapter,
     LocalFilesystemAdapter,
+    build_path_renamer_ports,
 )
 from omym.features.metadata.usecases.ports import FilesystemPort, RomanizationPort
 from omym.platform.db.cache.artist_cache_dao import ArtistCacheDAO
@@ -113,6 +112,7 @@ def processor(mocker: MockerFixture, tmp_path: Path, file_hash: str) -> MusicPro
         romanization_port=romanization_port,
         preview_cache=preview_dao,
         filesystem=filesystem,
+        renamer_ports=build_path_renamer_ports(artist_dao),
     )
     romanization_port.configure_cache.assert_called_once_with(artist_dao)
 
@@ -1321,6 +1321,7 @@ class TestMusicProcessor:
             romanization_port=romanization_port,
             preview_cache=stub_preview,
             filesystem=LocalFilesystemAdapter(),
+            renamer_ports=build_path_renamer_ports(stub_artist),
         )
 
         assert processor.db_manager is stub_db
@@ -1385,6 +1386,7 @@ def test_dry_run_skips_persistent_state(
         romanization_port=romanization_port,
         preview_cache=preview_dao,
         filesystem=LocalFilesystemAdapter(),
+        renamer_ports=build_path_renamer_ports(artist_cache),
     )
     romanization_port.configure_cache.assert_called_once_with(artist_cache)
     target_candidate = destination_dir / "Track.mp3"

--- a/tests/features/metadata/usecases/test_artist_cache_adapter.py
+++ b/tests/features/metadata/usecases/test_artist_cache_adapter.py
@@ -9,8 +9,7 @@ from pathlib import Path
 from sqlite3 import Connection
 from typing import cast
 
-from omym.features.metadata.adapters import DryRunArtistCacheAdapter
-from omym.features.path.usecases.renamer import ArtistIdGenerator
+from omym.features.metadata.adapters import DryRunArtistCacheAdapter, build_path_renamer_ports
 from omym.platform.db.cache.artist_cache_dao import ArtistCacheDAO
 from omym.platform.db.db_manager import DatabaseManager
 
@@ -30,7 +29,8 @@ def _build_adapter(
 def test_dry_run_adapter_persists_artist_ids(tmp_path: Path) -> None:
     manager, conn, adapter = _build_adapter(tmp_path)
     try:
-        expected_id = ArtistIdGenerator.generate("John Smith")
+        renamer_ports = build_path_renamer_ports(adapter)
+        expected_id = renamer_ports.artist_id.generate("John Smith")
         assert adapter.insert_artist_id("John Smith", expected_id) is True
         assert adapter.get_artist_id("John Smith") == expected_id
 


### PR DESCRIPTION
## Summary
- define explicit renamer ports for metadata use cases and accept them through `MusicProcessor`
- implement a path-backed renamer adapter and inject it via `OrganizeMusicService`
- refactor processing helpers and tests to rely on the new ports while tightening architecture checks

## Testing
- uv run basedpyright
- uv run pytest -q --maxfail=1 --tb=line --show-capture=stdout

------
https://chatgpt.com/codex/tasks/task_e_68e107ea8ea8832aa8f006c8f6e1df69